### PR TITLE
Dockerfile - Add  pip install -e .

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ COPY pyproject.toml .
 COPY licences.json .
 
 RUN pip install -r requirements.txt
+RUN pip install -e .
 
 COPY src/ src
 


### PR DESCRIPTION
Solves the "Could not initialise application - error setting up context No package metadata was found for register-your-data-api" error.

Added after installing the locked file requirements, so the locked requirements are installed first and then this stage should say "Requirement already satisfied" and not change them.