### PR TITLE
Add SuiteCRMClient factory with access token caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 
+## [0.1.8] - 2025-11-21
+
+### Added
+
+ - SuiteCRMClientFactory class which generates SuiteCRM clients using a cached
+   access token and refreshes the token when needed.
+
 ## [0.1.6] - 2025-11-19
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "register-your-data-api"
-version = "0.1.7"
+version = "0.1.8"
 requires-python = ">= 3.12.11"
 readme = "README.md"
 authors = [{name="IATI Secretariat", email="support@iatistandard.org"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "click",
     "cryptography==45.0.5",
     "fastapi[standard]==0.116.0",
-    "libsuitecrm @ git+https://github.com/iati/iati-registry-libsuitecrm",
+    "libsuitecrm @ git+https://github.com/iati/iati-registry-libsuitecrm@v0.3.0",
     "prometheus-client>=0.22.1",
     "pyjwt>=2.10.0",
     "python-dotenv>=1.1.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,7 +65,7 @@ idna==3.10
     #   requests
 jinja2==3.1.6
     # via fastapi
-libsuitecrm @ git+https://github.com/iati/iati-registry-libsuitecrm
+libsuitecrm @ git+https://github.com/iati/iati-registry-libsuitecrm@v0.3.0
     # via register-your-data-api (pyproject.toml)
 mako==1.3.10
     # via alembic

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -87,7 +87,7 @@ isort==6.0.1
     # via register-your-data-api (pyproject.toml)
 jinja2==3.1.6
     # via fastapi
-libsuitecrm @ git+https://github.com/iati/iati-registry-libsuitecrm
+libsuitecrm @ git+https://github.com/iati/iati-registry-libsuitecrm@v0.3.0
     # via register-your-data-api (pyproject.toml)
 mako==1.3.10
     # via alembic

--- a/src/register_your_data_api/routers/datasets.py
+++ b/src/register_your_data_api/routers/datasets.py
@@ -37,9 +37,7 @@ def create_dataset(
 
     context: Context = request.app.state.context
 
-    crm: SuiteCRM = context.get_suitecrm_client()
-
-    crm.fetch_access_token()
+    crm: SuiteCRM = context.suitecrm_client_factory.get_client()
 
     if not user.validator.user_can_create_reporting_org_datasets(uuid.UUID(dataset.owner_organisation_id)):
         context.audit_logger.error(
@@ -83,9 +81,7 @@ def get_dataset_detail(
 
     context: Context = request.app.state.context
 
-    crm: SuiteCRM = context.get_suitecrm_client()
-
-    crm.fetch_access_token()
+    crm: SuiteCRM = context.suitecrm_client_factory.get_client()
 
     ds_filters = Filter()
     ds_filters.equal("id", str(dataset_id))
@@ -129,9 +125,7 @@ def update_dataset(
 
     context: Context = request.app.state.context
 
-    crm: SuiteCRM = context.get_suitecrm_client()
-
-    crm.fetch_access_token()
+    crm: SuiteCRM = context.suitecrm_client_factory.get_client()
 
     # Fetch the original dataset record so we know which reporting org it belongs to
     ds_filters = Filter()
@@ -201,9 +195,7 @@ def delete_dataset(
 
     context: Context = request.app.state.context
 
-    crm: SuiteCRM = context.get_suitecrm_client()
-
-    crm.fetch_access_token()
+    crm: SuiteCRM = context.suitecrm_client_factory.get_client()
 
     # Fetch the original dataset record so we know which reporting org it belongs to
     ds_filters = Filter()

--- a/src/register_your_data_api/routers/discoverable_reporting_orgs.py
+++ b/src/register_your_data_api/routers/discoverable_reporting_orgs.py
@@ -30,9 +30,7 @@ def get_discoverable_reporting_orgs(
 
     context: Context = request.app.state.context
 
-    crm: SuiteCRM = context.get_suitecrm_client()
-
-    crm.fetch_access_token()
+    crm: SuiteCRM = context.suitecrm_client_factory.get_client()
 
     fields = get_discoverable_reporting_org_suitecrm_fields()
 
@@ -51,7 +49,5 @@ def get_discoverable_reporting_orgs(
     # SuiteCRM doesn't return the total_records, so we set page size = 1, limit fields to id and fetch one record
     total_records_resp = crm.get_records("Accounts", filters=filters, fields=["id"], page_number=1, page_size=1)
     total_records = total_records_resp.get("meta", {}).get("total-pages", 1)
-
-    crm.logout()
 
     return PaginatedResultsPage.create(discoverable_orgs, paging.page, paging.page_size, total_records, request)

--- a/src/register_your_data_api/routers/reporting_orgs.py
+++ b/src/register_your_data_api/routers/reporting_orgs.py
@@ -58,9 +58,7 @@ def get_reporting_orgs(
 
     if len(user_reporting_org_associations) > 0:
 
-        crm: SuiteCRM = context.get_suitecrm_client()
-
-        crm.fetch_access_token()
+        crm: SuiteCRM = context.suitecrm_client_factory.get_client()
 
         fields = SUITECRM_REPORTING_ORG_FIELDS
 
@@ -128,9 +126,7 @@ def get_reporting_org_detail(
     filters = Filter()
     filters.equal("id", str(org_id))
 
-    crm: SuiteCRM = context.get_suitecrm_client()
-
-    crm.fetch_access_token()
+    crm: SuiteCRM = context.suitecrm_client_factory.get_client()
 
     fields = SUITECRM_REPORTING_ORG_FIELDS
 
@@ -175,9 +171,7 @@ def create_reporting_org(
 
     undo_actions: list[tuple[str, Callable[[], Any]]] = []
 
-    crm: SuiteCRM = context.get_suitecrm_client()
-
-    crm.fetch_access_token()
+    crm: SuiteCRM = context.suitecrm_client_factory.get_client()
 
     try:
         # 1. Create the reporting on SuiteCRM
@@ -255,9 +249,7 @@ def update_reporting_org(
             "error to the provider of the tool you are using to access the IATI Registry.",
         )
 
-    crm: SuiteCRM = context.get_suitecrm_client()
-
-    crm.fetch_access_token()
+    crm: SuiteCRM = context.suitecrm_client_factory.get_client()
 
     # 1. Query SuiteCRM to check that the reporting_org exists
     if not check_crm_record_exists(crm, "Accounts", str(org_id)):
@@ -313,9 +305,7 @@ def delete_reporting_org(
         ),
     )
 
-    crm: SuiteCRM = context.get_suitecrm_client()
-
-    crm.fetch_access_token()
+    crm: SuiteCRM = context.suitecrm_client_factory.get_client()
 
     # 1. Query SuiteCRM to check that the reporting_org exists. We just fetch the item, because
     # we need to update it later on, and we need to know what its current state is for undo purposes.
@@ -381,8 +371,6 @@ def delete_reporting_org(
             detail=f"There was a problem deleting the reporting org. Error id: {error_trace_id}",
         )
 
-    crm.logout()
-
     return fastapi.responses.JSONResponse({"status": "success", "data": None, "error": None})
 
 
@@ -405,9 +393,7 @@ def get_reporting_org_users(
             "error to the provider of the tool you are using to access the IATI Registry.",
         )
 
-    crm: SuiteCRM = context.get_suitecrm_client()
-
-    crm.fetch_access_token()
+    crm: SuiteCRM = context.suitecrm_client_factory.get_client()
 
     current_user_role_for_ro = user.validator.get_user_role_for_reporting_org(org_id)
 
@@ -486,9 +472,7 @@ def get_reporting_org_datasets(
             "error to the provider of the tool you are using to access the IATI Registry.",
         )
 
-    crm: SuiteCRM = context.get_suitecrm_client()
-
-    crm.fetch_access_token()
+    crm: SuiteCRM = context.suitecrm_client_factory.get_client()
 
     # 1. Check that the Reporting Org exists in the CRM
     if not check_crm_record_exists(crm, "Accounts", str(org_id)):

--- a/src/register_your_data_api/routers/users.py
+++ b/src/register_your_data_api/routers/users.py
@@ -60,9 +60,7 @@ def add_user_to_reporting_org(
         )
 
     # Query SuiteCRM to check that the reporting_org exists
-    crm: SuiteCRM = context.get_suitecrm_client()
-
-    crm.fetch_access_token()
+    crm: SuiteCRM = context.suitecrm_client_factory.get_client()
 
     if not check_crm_record_exists(crm, "Accounts", payload.oid):
         raise HTTPException(
@@ -128,9 +126,7 @@ def update_user_role_in_reporting_org(
     )
 
     # Get SuiteCRM client and validate entities exist
-    crm: SuiteCRM = context.get_suitecrm_client()
-
-    crm.fetch_access_token()
+    crm: SuiteCRM = context.suitecrm_client_factory.get_client()
 
     # 2. Check that the target user exists in CRM
     assert_precondition_met(
@@ -261,9 +257,7 @@ def remove_user_from_reporting_org(
     )
 
     # Get SuiteCRM client and validate entities exist
-    crm: SuiteCRM = context.get_suitecrm_client()
-
-    crm.fetch_access_token()
+    crm: SuiteCRM = context.suitecrm_client_factory.get_client()
 
     # 2. Check that the target user exists in CRM
     assert_precondition_met(

--- a/src/register_your_data_api/suitecrm_client_factory.py
+++ b/src/register_your_data_api/suitecrm_client_factory.py
@@ -1,0 +1,99 @@
+import logging
+import random
+import threading
+import time
+import uuid
+
+from libsuitecrm import AuthorisationFailed, SuiteCRM  # type: ignore
+
+
+class SuiteCRMClientFactory:
+    """A SuiteCRM client factory that creates clients using a cached access token and refreshes the token as needed"""
+
+    def __init__(
+        self,
+        app_logger: logging.Logger,
+        suitecrm_api_url: str,
+        suitecrm_client_id: str,
+        suitecrm_client_secret: str,
+        suitecrm_client_secure: bool = True,
+    ) -> None:
+        self._app_logger = app_logger
+        self._suitecrm_api_url = suitecrm_api_url
+        self._suitecrm_client_id = suitecrm_client_id
+        self._suitecrm_client_secret = suitecrm_client_secret
+        self._suitecrm_client_secure = suitecrm_client_secure
+
+        # config
+        self._buffer_seconds = 60
+
+        # token details
+        self._expires_at = 0
+
+        # lock for thread-safe access
+        self._lock = threading.Lock()
+
+        # A private SuiteCRM instance used to refresh the access token, which is shared as needed
+        self._private_crm = SuiteCRM(
+            self._suitecrm_api_url,
+            self._suitecrm_client_id,
+            self._suitecrm_client_secret,
+            self._suitecrm_client_secure,
+        )
+
+    def get_client(self) -> SuiteCRM:
+        """Gets a new SuiteCRM client using cached access token, refreshing the access token first if necessary"""
+
+        if self._private_crm.export_access_token() is not None and time.time() < self._expires_at:
+            self._app_logger.info(f"Thread {threading.get_ident()}: SuiteCRM access token ok, making new client.")
+            return self._get_new_suitecrm_client()
+
+        with self._lock:
+            if self._private_crm.export_access_token() is not None and time.time() < self._expires_at:
+                return self._private_crm
+
+            self._refresh_token()
+
+        return self._get_new_suitecrm_client()
+
+    def _get_new_suitecrm_client(self) -> SuiteCRM:
+        """Creates a new instance of the SuiteCRM client using the cached access token"""
+
+        access_token_dict = self._private_crm.export_access_token()
+
+        return SuiteCRM(
+            self._suitecrm_api_url,
+            self._suitecrm_client_id,
+            self._suitecrm_client_secret,
+            self._suitecrm_client_secure,
+            access_token_dict,
+        )
+
+    def _refresh_token(self) -> None:
+        """Fetch a token from SuiteCRM and adjust the refresh time"""
+
+        # NOTE: The strings 'Fetching new token' and 'Refreshing token' are used in unit tests
+        if self._private_crm.export_access_token() is None:
+            self._app_logger.info(
+                f"Thread {threading.get_ident()}: No SuiteCRM access token found. Fetching new token."
+            )
+        else:
+            self._app_logger.info(
+                f"Thread {threading.get_ident()}: SuiteCRM access token has expired. Refreshing token."
+            )
+
+        try:
+            self._private_crm.fetch_access_token()
+        except AuthorisationFailed as e:
+            error_id = uuid.uuid4()
+            self._app_logger.error(
+                f"Thread {threading.get_ident()}: Failed to refresh SuiteCRM "
+                f"access token: {str(e)}. Error id: {error_id}"
+            )
+            raise RuntimeError(f"There was a problem completing this request. Error trace id: {error_id}") from e
+
+        jitter = random.randint(0, 30)  # nosec
+
+        self._expires_at = (
+            time.time() + self._private_crm.export_access_token().get("expires_in", 0) - self._buffer_seconds - jitter
+        )

--- a/src/register_your_data_api/util.py
+++ b/src/register_your_data_api/util.py
@@ -9,8 +9,9 @@ from typing import Any, Final, TextIO, Type
 
 import dotenv
 import jwt
-from libsuitecrm import SuiteCRM  # type: ignore
 from prometheus_client import Counter, Gauge, Info, disable_created_metrics
+
+from register_your_data_api.suitecrm_client_factory import SuiteCRMClientFactory
 
 from .audit import EncryptedFormatter
 from .auth.fga.fga_provider import FineGrainedAuthorisationProvider
@@ -126,6 +127,10 @@ class Context:
         self._suitecrm_client_id = self._env["DATA_REGISTRY_SUITECRM_CLIENT_ID"]
         self._suitecrm_client_secret = self._env["DATA_REGISTRY_SUITECRM_CLIENT_SECRET"]
 
+        self._suitecrm_client_factory = SuiteCRMClientFactory(
+            self._app_logger, self._suitecrm_api_url, self._suitecrm_client_id, self._suitecrm_client_secret
+        )
+
         # self._crm_uuid_provider = UserCRMUUIDProviderAsgardeo(self._env["USER_CRM_UUID_CONFIG_STRING"])
 
         try:
@@ -143,9 +148,6 @@ class Context:
                 metric.inc()
             else:
                 metric.labels(failure_mode=failure_mode_label).inc()
-
-    def get_suitecrm_client(self) -> SuiteCRM:
-        return SuiteCRM(self._suitecrm_api_url, self._suitecrm_client_id, self._suitecrm_client_secret)
 
     def __del__(self) -> None:
         try:
@@ -330,3 +332,7 @@ class Context:
     @property
     def suitecrm_client_secret(self) -> str:
         return self._suitecrm_client_secret
+
+    @property
+    def suitecrm_client_factory(self) -> SuiteCRMClientFactory:
+        return self._suitecrm_client_factory

--- a/tests/helpers/mocking.py
+++ b/tests/helpers/mocking.py
@@ -11,7 +11,6 @@ import sqlmodel
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from fastapi import FastAPI
-from libsuitecrm import SuiteCRM  # type: ignore
 
 import register_your_data_api.util as util
 from main import add_routers_and_general_exception_handling
@@ -26,6 +25,19 @@ from tests.helpers.keys import KeyDict
 from ..helpers import prom
 from .mocked_objects.mock_suitecrm import MockSuiteCRM
 from .setup_and_teardown import setup_db
+
+
+class StringContaining:
+    def __init__(self, substring: str) -> None:
+        self.substring = substring
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, str):
+            return NotImplemented
+        return self.substring in other
+
+    def __repr__(self) -> str:
+        return f"<StringContaining '{self.substring}'>"
 
 
 class MockKeyStore:
@@ -136,8 +148,13 @@ class MockedTestContext(util.Context):
     def _setup_key_store(self) -> None:
         self._key_store = MockKeyStore()  # type: ignore
 
-    def get_suitecrm_client(self) -> SuiteCRM:
-        return self._mocked_suitecrm_client
+    @property
+    def suitecrm_client_factory(self) -> object:  # type: ignore
+        class MockedSuiteCRMClientFactory:
+            def get_client(inner_self) -> MockSuiteCRM:
+                return self._mocked_suitecrm_client
+
+        return MockedSuiteCRMClientFactory()
 
 
 class MockedAppAndContext:

--- a/tests/unit/test_suitecrm_client_factory.py
+++ b/tests/unit/test_suitecrm_client_factory.py
@@ -1,0 +1,112 @@
+import time
+from typing import Callable
+from unittest import mock
+
+from register_your_data_api.suitecrm_client_factory import SuiteCRMClientFactory
+
+from ..helpers.mocking import StringContaining
+
+
+def mock_token_creator_factory(suitecrm_client_factory: SuiteCRMClientFactory, expires_in: int) -> Callable[[], None]:
+    def mock_fetch_token() -> None:
+        suitecrm_client_factory._private_crm.export_access_token.return_value = {
+            "access_token": "new-access-token",
+            "expires_in": expires_in,
+            "expires_at": time.time() + expires_in,
+        }
+
+    return mock_fetch_token
+
+
+def test_token_created() -> None:
+
+    access_token_cache = SuiteCRMClientFactory(
+        app_logger=mock.Mock(),
+        suitecrm_api_url="http://example.com",
+        suitecrm_client_id="client-test-id",
+        suitecrm_client_secret="client-test-secret",  # nosec B106
+    )
+
+    access_token_cache._private_crm = mock.Mock()
+
+    access_token_cache._private_crm.export_access_token.return_value = None
+
+    access_token_cache._private_crm.fetch_access_token.side_effect = mock_token_creator_factory(
+        access_token_cache, 3600
+    )
+
+    access_token_cache.get_client()
+
+    # check that log message reads "No token found"
+    access_token_cache._app_logger.info.assert_called_with(StringContaining("Fetching new token."))  # type: ignore
+
+
+def test_token_refreshed() -> None:
+
+    access_token_cache = SuiteCRMClientFactory(
+        app_logger=mock.MagicMock(),
+        suitecrm_api_url="http://example.com",
+        suitecrm_client_id="client-test-id",
+        suitecrm_client_secret="client-test-secret",  # nosec B106
+    )
+
+    access_token_cache._private_crm = mock.MagicMock()
+
+    access_token_cache._private_crm.export_access_token.return_value = None
+
+    def mock_fetch_token() -> None:
+        access_token_cache._private_crm.export_access_token.return_value = {
+            "access_token": "new-access-token",
+            "expires_in": 1,
+            "expires_at": time.time() + 1,
+        }
+
+    access_token_cache._private_crm.fetch_access_token.side_effect = mock_token_creator_factory(access_token_cache, 1)
+
+    access_token_cache.get_client()
+
+    first_access_token = access_token_cache._private_crm.export_access_token()
+
+    # check that log message reads "Fetching new token"
+    access_token_cache._app_logger.info.assert_called_with(StringContaining("Fetching new token."))  # type: ignore
+
+    time.sleep(2)
+
+    access_token_cache.get_client()
+
+    second_access_token = access_token_cache._private_crm.export_access_token()
+
+    # check that log message includes "Refreshing token"
+    access_token_cache._app_logger.info.assert_called_with(StringContaining("Refreshing token."))  # type: ignore
+
+    # check that the access tokens are different
+    assert first_access_token != second_access_token
+
+
+def test_new_instance_of_client_returned_with_same_token() -> None:
+
+    access_token_cache = SuiteCRMClientFactory(
+        app_logger=mock.Mock(),
+        suitecrm_api_url="http://example.com",
+        suitecrm_client_id="client-test-id",
+        suitecrm_client_secret="client-test-secret",  # nosec B106
+    )
+
+    access_token_cache._private_crm = mock.MagicMock()
+
+    access_token_cache._private_crm.export_access_token.return_value = None
+
+    access_token_cache._private_crm.export_access_token.return_value = {
+        "access_token": "access-token",
+        "expires_in": 3600,
+        "expires_at": time.time() + 3600,
+    }
+
+    client1 = access_token_cache.get_client()
+    client2 = access_token_cache.get_client()
+
+    # check that the clients are different instances of SuiteCRM
+    assert client1 is not client2
+
+    # check that both clients have the same access token
+    assert client1.export_access_token() == client2.export_access_token()


### PR DESCRIPTION
This PR uses additions in v0.3.0 of https://github.com/IATI/iati-registry-libsuitecrm to import/export the SuiteCRM access token.

This functionality is wrapped in a `SuiteCRMClientFactory` class which is responsible for returning a SuiteCRM client to the request handlers. This class takes care of refreshing the access token when it is close to expiry.