### PR TITLE
Send custom headers for auditing to SuiteCRM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /api
 COPY requirements.txt .
 COPY pyproject.toml .
 COPY licences.json .
+COPY ryd-client-applications-metadata.json .
 
 RUN pip install -r requirements.txt
 RUN pip install -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "register-your-data-api"
-version = "0.1.9"
+version = "0.2.0"
 requires-python = ">= 3.12.11"
 readme = "README.md"
 authors = [{name="IATI Secretariat", email="support@iatistandard.org"}]
@@ -12,7 +12,7 @@ dependencies = [
     "click",
     "cryptography==45.0.5",
     "fastapi[standard]==0.116.0",
-    "libsuitecrm @ git+https://github.com/iati/iati-registry-libsuitecrm@v0.3.0",
+    "libsuitecrm @ git+https://github.com/iati/iati-registry-libsuitecrm@v0.4.0",
     "prometheus-client>=0.22.1",
     "pyjwt>=2.10.0",
     "python-dotenv>=1.1.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,7 +65,7 @@ idna==3.10
     #   requests
 jinja2==3.1.6
     # via fastapi
-libsuitecrm @ git+https://github.com/iati/iati-registry-libsuitecrm@v0.3.0
+libsuitecrm @ git+https://github.com/iati/iati-registry-libsuitecrm@v0.4.0
     # via register-your-data-api (pyproject.toml)
 mako==1.3.10
     # via alembic

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -87,7 +87,7 @@ isort==6.0.1
     # via register-your-data-api (pyproject.toml)
 jinja2==3.1.6
     # via fastapi
-libsuitecrm @ git+https://github.com/iati/iati-registry-libsuitecrm@v0.3.0
+libsuitecrm @ git+https://github.com/iati/iati-registry-libsuitecrm@v0.4.0
     # via register-your-data-api (pyproject.toml)
 mako==1.3.10
     # via alembic

--- a/src/register_your_data_api/auth/authn.py
+++ b/src/register_your_data_api/auth/authn.py
@@ -161,7 +161,7 @@ async def validate_and_decode_token(  # noqa: C901
             "provider of the tool you are using to access the IATI Registry.",
         )
 
-    REQUIRED_CLAIMS = set(["sub", "scope", "aud", "iatiRegistryId"])
+    REQUIRED_CLAIMS = set(["sub", "scope", "aud", "iatiRegistryId", "client_id"])
     if len(REQUIRED_CLAIMS.difference(decoded_token)) > 0:
         context.prom_counter_metric_inc("requests_auth_failed_invalid_jwt_total", "missing_data")
         context.audit_logger.critical(
@@ -235,6 +235,7 @@ async def parse_decoded_token(
     # Make user object and return.
     user = UserAndCredentials(
         access_token=raw_token,
+        client_id=token["client_id"],
         sub=token["sub"],
         scopes=token["scope"],
         audience=token["aud"],

--- a/src/register_your_data_api/auth/models.py
+++ b/src/register_your_data_api/auth/models.py
@@ -7,6 +7,7 @@ class UserAndCredentials(pydantic.BaseModel):
     """Class to contain user information and credentials obtained from the access token, CRM and identity service"""
 
     access_token: str  # Store the raw access token b/c we need to use to make requests to Asgardeo
+    client_id: str
     sub: str  # User ID in the identity service.
     user_id_crm: str  # ID of Person in the CRM.
     scopes: str  # Scopes that the access token has (from the identity service).

--- a/src/register_your_data_api/client_application_details_provider.py
+++ b/src/register_your_data_api/client_application_details_provider.py
@@ -1,0 +1,51 @@
+from typing import Annotated
+from uuid import UUID
+
+from pydantic import AfterValidator, BaseModel, Field, TypeAdapter
+
+
+def check_uuid(v: str) -> str:
+    try:
+        UUID(v)
+    except ValueError:
+        raise ValueError("Invalid UUID string")
+    return v
+
+
+UUIDStr = Annotated[str, AfterValidator(check_uuid)]
+
+
+class ClientApplicationDetails(BaseModel):
+    client_id: str = Field(min_length=1)
+    application_id: UUIDStr
+    application_name: str
+
+
+class ClientApplicationDetailsProvider:
+
+    _CLIENT_APPLICATION_DETAILS: dict[str, ClientApplicationDetails] = {}
+
+    def __init__(self, filename: str) -> None:
+        """Initializes the provider by loading client application details from a JSON file."""
+
+        try:
+            with open(filename, "r") as file:
+                data = file.read()
+                type_adapter = TypeAdapter(list[ClientApplicationDetails])
+                client_app_details_list = type_adapter.validate_json(data)
+
+                for app_details in client_app_details_list:
+                    if app_details.client_id in self._CLIENT_APPLICATION_DETAILS:
+                        raise RuntimeError(f"Duplicate client_id found in {filename}: {app_details.client_id}")
+                    self._CLIENT_APPLICATION_DETAILS[app_details.client_id] = app_details
+
+        except Exception as e:
+            raise RuntimeError(f"Failed to load client application details from {filename}: {e}")
+
+    def get_client_application_details(self, client_id: str) -> ClientApplicationDetails:
+        """Retrieves details about the client application given its client ID."""
+
+        if client_id not in self._CLIENT_APPLICATION_DETAILS:
+            raise ValueError("Unknown client application")
+
+        return self._CLIENT_APPLICATION_DETAILS[client_id]

--- a/src/register_your_data_api/dependencies.py
+++ b/src/register_your_data_api/dependencies.py
@@ -1,0 +1,22 @@
+import starlette.requests
+from fastapi import Security
+
+from register_your_data_api.auth import authz
+from register_your_data_api.util import Context
+
+
+def get_suitecrm_audit_headers(
+    request: starlette.requests.Request,
+    user: authz.UserAndCredentials = Security(authz.get_user_authnz, scopes=["ryd"]),  # type: ignore
+) -> dict[str, str]:
+    """Get the set of custom headers for submitting a write-request to SuiteCRM"""
+
+    context: Context = request.app.state.context
+
+    client_app_details = context.get_client_application_details(user.client_id)
+
+    return {
+        "IATI-Person-ID": user.user_id_crm,
+        "IATI-UserApplication-ID": client_app_details.application_id,
+        "IATI-UserApplication-Name": client_app_details.application_name,
+    }

--- a/src/register_your_data_api/routers/datasets.py
+++ b/src/register_your_data_api/routers/datasets.py
@@ -4,10 +4,12 @@ import uuid
 
 import fastapi
 import starlette
-from fastapi import Security
+from fastapi import Depends, Security
 from fastapi.exceptions import HTTPException
 from fastapi.responses import JSONResponse
 from libsuitecrm import Filter, SuiteCRM  # type: ignore
+
+from register_your_data_api.dependencies import get_suitecrm_audit_headers
 
 from ..auth import authz
 from ..auth import models as auth_models
@@ -33,6 +35,7 @@ def create_dataset(
     request: starlette.requests.Request,
     dataset: DatasetCreateModel,
     user: auth_models.UserAndCredentials = Security(authz.get_user_authnz, scopes=["ryd", "ryd:dataset"]),
+    suitecrm_audit_headers: dict[str, str] = Depends(get_suitecrm_audit_headers),
 ) -> DatasetSingleResponse:
 
     context: Context = request.app.state.context
@@ -60,7 +63,7 @@ def create_dataset(
 
     # Create the record on SuiteCRM to add the dataset
     dataset_for_suitecrm = get_suitecrm_dict_from_dataset(dataset)
-    suitecrm_dataset = crm.create_record("IATI_Datasets", dataset_for_suitecrm)
+    suitecrm_dataset = crm.create_record("IATI_Datasets", dataset_for_suitecrm, headers=suitecrm_audit_headers)
     new_dataset = get_dataset_meta_from_suitecrm_response(suitecrm_dataset["attributes"])
 
     return DatasetSingleResponse(
@@ -121,6 +124,7 @@ def update_dataset(
     user: auth_models.UserAndCredentials = Security(
         authz.get_user_authnz, scopes=["ryd", "ryd:dataset", "ryd:dataset:update"]
     ),
+    suitecrm_audit_headers: dict[str, str] = Depends(get_suitecrm_audit_headers),
 ) -> DatasetSingleResponse:
 
     context: Context = request.app.state.context
@@ -174,7 +178,9 @@ def update_dataset(
     if dataset.visibility is None:
         dataset_for_suitecrm.pop("iati_visibility", None)
 
-    suitecrm_dataset = crm.update_record("IATI_Datasets", str(dataset_id), dataset_for_suitecrm)
+    suitecrm_dataset = crm.update_record(
+        "IATI_Datasets", str(dataset_id), dataset_for_suitecrm, headers=suitecrm_audit_headers
+    )
     updated_dataset = get_dataset_meta_from_suitecrm_response(suitecrm_dataset["attributes"])
 
     return DatasetSingleResponse(
@@ -191,6 +197,7 @@ def delete_dataset(
     dataset_id: uuid.UUID,
     request: starlette.requests.Request,
     user: auth_models.UserAndCredentials = Security(authz.get_user_authnz, scopes=["ryd", "ryd:dataset:delete"]),
+    suitecrm_audit_headers: dict[str, str] = Depends(get_suitecrm_audit_headers),
 ) -> JSONResponse:
 
     context: Context = request.app.state.context
@@ -228,7 +235,7 @@ def delete_dataset(
     )
 
     try:
-        crm.delete_record("IATI_Datasets", str(dataset_id))
+        crm.delete_record("IATI_Datasets", str(dataset_id), headers=suitecrm_audit_headers)
     except Exception:
         error_id = uuid.uuid4()
         context.app_logger.exception(

--- a/src/register_your_data_api/routers/reporting_orgs.py
+++ b/src/register_your_data_api/routers/reporting_orgs.py
@@ -5,10 +5,12 @@ from typing import Any, Callable
 
 import fastapi
 import starlette
-from fastapi import Security
+from fastapi import Depends, Security
 from fastapi.exceptions import HTTPException
 from fastapi.responses import JSONResponse
 from libsuitecrm import Filter, SuiteCRM  # type: ignore
+
+from register_your_data_api.dependencies import get_suitecrm_audit_headers
 
 from ..auth import authz
 from ..auth import models as auth_models
@@ -28,7 +30,6 @@ from ..data_handling.data_schemas import (
     DiscoverableReportingOrgMetadata,
     PaginationQueryParams,
     ReportingOrgAction,
-    ReportingOrgCreateModel,
     ReportingOrgMetadata,
     ReportingOrgUpdateModel,
     ReportingOrgUserCreateModel,
@@ -162,6 +163,7 @@ def create_reporting_org(
     user: auth_models.UserAndCredentials = Security(
         authz.get_user_authnz, scopes=["ryd", "ryd:reporting_org", "ryd:reporting_org:create"]
     ),
+    suitecrm_audit_headers: dict[str, str] = Depends(get_suitecrm_audit_headers),
 ) -> UserReportingOrgRelationSingleResponse:
 
     context: Context = request.app.state.context
@@ -179,15 +181,16 @@ def create_reporting_org(
     crm: SuiteCRM = context.suitecrm_client_factory.get_client()
 
     try:
-        # 1. Convert to a complete reporting org record, then to a SuiteCRM reporting org record
-        reporting_org_to_create = ReportingOrgCreateModel(**reporting_org.model_dump())
-        reporting_org_for_suitecrm = get_suitecrm_dict_from_reporting_org(reporting_org_to_create)
-        suitecrm_reporting_org = crm.create_record("Accounts", reporting_org_for_suitecrm)
+        # 1. Create the reporting on SuiteCRM
+        reporting_org_for_suitecrm = get_suitecrm_dict_from_reporting_org(reporting_org)
+        suitecrm_reporting_org = crm.create_record(
+            "Accounts", reporting_org_for_suitecrm, headers=suitecrm_audit_headers
+        )
         new_reporting_org = get_reporting_org_meta_from_suitecrm_response(suitecrm_reporting_org["attributes"])
         undo_actions.append(
             (
                 f"delete organisation with id: {suitecrm_reporting_org["id"]}",
-                lambda: crm.delete_record("Accounts", suitecrm_reporting_org["id"]),
+                lambda: crm.delete_record("Accounts", suitecrm_reporting_org["id"], headers=suitecrm_audit_headers),
             )
         )
 
@@ -195,13 +198,20 @@ def create_reporting_org(
         # reporting org (Accounts) in SuiteCRM, but only if user is not
         # operating in the capacity as a super_admin
         if not user.validator.is_superadmin:
-            crm.create_relationship("Accounts", suitecrm_reporting_org["id"], "contacts", "Contacts", user.user_id_crm)
+            crm.create_relationship(
+                "Accounts",
+                suitecrm_reporting_org["id"],
+                "contacts",
+                "Contacts",
+                user.user_id_crm,
+                headers=suitecrm_audit_headers,
+            )
             undo_msg = (
                 "delete relationship between organisation id: "
                 f"{suitecrm_reporting_org["id"]} and user id: {user.user_id_crm}"
             )
             undo_func: Callable[[], Any] = lambda: crm.delete_relationship(
-                "Accounts", suitecrm_reporting_org["id"], "contacts", user.user_id_crm
+                "Accounts", suitecrm_reporting_org["id"], "contacts", user.user_id_crm, headers=suitecrm_audit_headers
             )
             undo_actions.append((undo_msg, undo_func))
 
@@ -240,6 +250,7 @@ def update_reporting_org(
     user: auth_models.UserAndCredentials = Security(
         authz.get_user_authnz, scopes=["ryd", "ryd:reporting_org", "ryd:reporting_org:update"]
     ),
+    suitecrm_audit_headers: dict[str, str] = Depends(get_suitecrm_audit_headers),
 ) -> UserReportingOrgRelationSingleResponse:
 
     context: Context = request.app.state.context
@@ -267,7 +278,9 @@ def update_reporting_org(
     # 2. Make request to SuiteCRM to update reporting_org
     reporting_org_for_suitecrm = get_suitecrm_dict_from_reporting_org(updated_reporting_org)
     try:
-        suitecrm_reporting_org = crm.update_record("Accounts", str(org_id), reporting_org_for_suitecrm)
+        suitecrm_reporting_org = crm.update_record(
+            "Accounts", str(org_id), reporting_org_for_suitecrm, headers=suitecrm_audit_headers
+        )
         updated_reporting_org_from_suitecrm = get_reporting_org_meta_from_suitecrm_response(
             suitecrm_reporting_org["attributes"]
         )
@@ -292,6 +305,7 @@ def delete_reporting_org(
     org_id: uuid.UUID,
     request: starlette.requests.Request,
     user: auth_models.UserAndCredentials = Security(authz.get_user_authnz, scopes=["ryd", "ryd:reporting_org:delete"]),
+    suitecrm_audit_headers: dict[str, str] = Depends(get_suitecrm_audit_headers),
 ) -> JSONResponse:
 
     context: Context = request.app.state.context
@@ -343,26 +357,16 @@ def delete_reporting_org(
         # 2. Set iati_registry_approved and iati_registry_discoverable to 0
         crm.update_record("Accounts", str(org_id), {"iati_registry_approved": "0", "iati_registry_discoverable": "0"})
 
-        # Only if one of the fields was true, create an undo action setting the fields back to their original values
-        if (
-            crm_reporting_org["data"][0].get("attributes", {}).get("iati_registry_approved") == "1"
-            or crm_reporting_org["data"][0].get("attributes", {}).get("iati_registry_discoverable") == "1"
-        ):
+        # TODO: 2b. Set iati_registry_discoverable to False when that new field is
+        # available on SuiteCRM.
+        crm.update_record("Accounts", str(org_id), {"iati_registry_approved": False})
+
+        if crm_reporting_org["data"][0].get("attributes", {}).get("iati_registry_approved") is True:
+            # Only need to add undo action if the field was previously True
             undo_actions.append(
                 (
                     f"Set iati_registry_approved back to True for organisation with id: {str(org_id)}",
-                    lambda: crm.update_record(
-                        "Accounts",
-                        str(org_id),
-                        {
-                            "iati_registry_approved": crm_reporting_org["data"][0]
-                            .get("attributes", {})
-                            .get("iati_registry_approved"),
-                            "iati_registry_discoverable": crm_reporting_org["data"][0]
-                            .get("attributes", {})
-                            .get("iati_registry_discoverable"),
-                        },
-                    ),
+                    lambda: crm.update_record("Accounts", str(org_id), {"iati_registry_approved": True}),
                 )
             )
 
@@ -375,7 +379,7 @@ def delete_reporting_org(
         datasets_from_suitecrm = crm.get_records("IATI_Datasets", filters=filters, fields=["id"], page_size=1500)
         for dataset in datasets_from_suitecrm.get("data", []):
             dataset_id = dataset["id"]
-            crm.delete_record("IATI_Datasets", dataset_id)
+            crm.delete_record("IATI_Datasets", dataset_id, headers=suitecrm_audit_headers)
 
         context.audit_logger.info(
             f"User {user.user_id_crm} deleted reporting org {org_id} with its "

--- a/src/register_your_data_api/routers/users.py
+++ b/src/register_your_data_api/routers/users.py
@@ -5,10 +5,12 @@ from typing import Any, Callable
 
 import fastapi
 import starlette
-from fastapi import Security
+from fastapi import Depends, Security
 from fastapi.exceptions import HTTPException
 from fastapi.responses import JSONResponse
 from libsuitecrm import SuiteCRM  # type: ignore
+
+from register_your_data_api.dependencies import get_suitecrm_audit_headers
 
 from ..auth import authz
 from ..auth.fga import models as fga_models
@@ -35,6 +37,7 @@ def add_user_to_reporting_org(
     payload: OrganisationId,
     request: starlette.requests.Request,
     user: UserAndCredentials = Security(authz.get_user_authnz, scopes=["ryd", "ryd:reporting_org:user"]),
+    suitecrm_audit_headers: dict[str, str] = Depends(get_suitecrm_audit_headers),
 ) -> JSONResponse:
     """Handles a request by the logged in user to be associated with the specified reporting_org"""
 
@@ -72,10 +75,12 @@ def add_user_to_reporting_org(
 
     try:
         # 1. Create a relationship between the current user (Contacts) and the
-        crm.create_relationship("Accounts", payload.oid, "contacts", "Contacts", user.user_id_crm)
+        crm.create_relationship(
+            "Accounts", payload.oid, "contacts", "Contacts", user.user_id_crm, headers=suitecrm_audit_headers
+        )
         undo_msg = f"delete relationship between organisation id: {payload.oid} and user id: {user.user_id_crm}"
         undo_func: Callable[[], Any] = lambda: crm.delete_relationship(
-            "Accounts", payload.oid, "contacts", user.user_id_crm
+            "Accounts", payload.oid, "contacts", user.user_id_crm, headers=suitecrm_audit_headers
         )
         undo_actions.append((undo_msg, undo_func))
 
@@ -105,6 +110,7 @@ def update_user_role_in_reporting_org(
     new_role: UserRoleUpdateModel,
     request: starlette.requests.Request,
     user: UserAndCredentials = Security(authz.get_user_authnz, scopes=["ryd", "ryd:reporting_org:user:update"]),
+    suitecrm_audit_headers: dict[str, str] = Depends(get_suitecrm_audit_headers),
 ) -> JSONResponse:
     """Updates a user's role within a reporting organization"""
 
@@ -181,7 +187,9 @@ def update_user_role_in_reporting_org(
             "Creating relationship in the CRM."
         )
         try:
-            crm.create_relationship("Accounts", str(org_id), "contacts", "Contacts", str(user_id))
+            crm.create_relationship(
+                "Accounts", str(org_id), "contacts", "Contacts", str(user_id), headers=suitecrm_audit_headers
+            )
         except Exception as e:
             context.app_logger.exception(
                 "Exception encountered when attempting to create the relationship in the CRM between "
@@ -236,6 +244,7 @@ def remove_user_from_reporting_org(
     org_id: uuid.UUID,
     request: starlette.requests.Request,
     user: UserAndCredentials = Security(authz.get_user_authnz, scopes=["ryd", "ryd:reporting_org:user:update"]),
+    suitecrm_audit_headers: dict[str, str] = Depends(get_suitecrm_audit_headers),
 ) -> JSONResponse:
     """Removes a user's role in a reporting organization"""
 

--- a/src/register_your_data_api/util.py
+++ b/src/register_your_data_api/util.py
@@ -11,6 +11,10 @@ import dotenv
 import jwt
 from prometheus_client import Counter, Gauge, Info, disable_created_metrics
 
+from register_your_data_api.client_application_details_provider import (
+    ClientApplicationDetails,
+    ClientApplicationDetailsProvider,
+)
 from register_your_data_api.suitecrm_client_factory import SuiteCRMClientFactory
 
 from .audit import EncryptedFormatter
@@ -36,6 +40,7 @@ class Context:
         "DATA_REGISTRY_SUITECRM_CLIENT_ID",
         "DATA_REGISTRY_SUITECRM_CLIENT_SECRET",
         "USER_CRM_UUID_CONFIG_STRING",
+        "CLIENT_APPLICATION_DETAILS_FILE",
     ]
 
     LOG_LEVELS: Final[dict[str, int]] = {
@@ -103,10 +108,17 @@ class Context:
         self._app_logger.info(f"Register Your Data {self.VERSION}")
 
         try:
+            self._app_logger.info("Setting up client application details provider")
+            self._setup_client_application_details_provider()
+        except Exception as err:
+            self._app_logger.fatal(f"Cannot setup client application details provider ({err})")
+            raise err
+
+        try:
             self._app_logger.info("Setting up JWK store")
             self._setup_key_store()
         except Exception as err:
-            self._app_logger.fatal(f"Cannot not setup JWK key store ({err})")
+            self._app_logger.fatal(f"Cannot setup JWK key store ({err})")
             raise err
 
         try:
@@ -154,6 +166,9 @@ class Context:
             self._app_log_fh.close()
         except AttributeError:
             pass
+
+    def _setup_client_application_details_provider(self) -> None:
+        self._client_app_details = ClientApplicationDetailsProvider(self._env["CLIENT_APPLICATION_DETAILS_FILE"])
 
     def _setup_prom_metrics(self) -> None:
         """Add all the prometheus metrics"""
@@ -336,3 +351,8 @@ class Context:
     @property
     def suitecrm_client_factory(self) -> SuiteCRMClientFactory:
         return self._suitecrm_client_factory
+
+    def get_client_application_details(self, client_id: str) -> ClientApplicationDetails:
+        """Retrieves details about the client application given its client ID."""
+
+        return self._client_app_details.get_client_application_details(client_id)

--- a/tests/helpers/mocked_objects/mock_suitecrm.py
+++ b/tests/helpers/mocked_objects/mock_suitecrm.py
@@ -83,7 +83,9 @@ class MockSuiteCRM:
 
         return response
 
-    def create_record(self, module_name: str, data: dict[str, Any]) -> dict[str, Any]:
+    def create_record(
+        self, module_name: str, data: dict[str, Any], headers: dict[str, str] | None = None
+    ) -> dict[str, Any]:
         return {
             "id": str(uuid.uuid4()),
             "attributes": {
@@ -94,14 +96,22 @@ class MockSuiteCRM:
             },
         }
 
-    def update_record(self, module_name: str, id: str, data: dict[str, Any]) -> None:
+    def update_record(
+        self, module_name: str, id: str, data: dict[str, Any], headers: dict[str, str] | None = None
+    ) -> None:
         return None
 
-    def delete_record(self, module_name: str, id: str) -> None:
+    def delete_record(self, module_name: str, id: str, headers: dict[str, str] | None = None) -> None:
         return None
 
     def create_relationship(
-        self, module_name: str, record_id: str, link_field_name: str, related_module_name: str, related_id: str
+        self,
+        module_name: str,
+        record_id: str,
+        link_field_name: str,
+        related_module_name: str,
+        related_id: str,
+        headers: dict[str, str] | None = None,
     ) -> None:
         return None
 
@@ -120,5 +130,7 @@ class MockSuiteCRM:
 
         return response
 
-    def delete_relationship(self, module_name: str, id: str, link_field_name: str, related_id: str) -> None:
+    def delete_relationship(
+        self, module_name: str, id: str, link_field_name: str, related_id: str, headers: dict[str, str] | None = None
+    ) -> None:
         return None

--- a/tests/helpers/mocking.py
+++ b/tests/helpers/mocking.py
@@ -20,6 +20,7 @@ from register_your_data_api.auth.fga.fga_provider_db import (
     SuperAdminUserDbModel,
 )
 from register_your_data_api.auth.fga.models import FineGrainedAuthorisationRole
+from register_your_data_api.client_application_details_provider import ClientApplicationDetails
 from tests.helpers.keys import KeyDict
 
 from ..helpers import prom
@@ -155,6 +156,13 @@ class MockedTestContext(util.Context):
                 return self._mocked_suitecrm_client
 
         return MockedSuiteCRMClientFactory()
+
+    def get_client_application_details(self, client_id: str) -> ClientApplicationDetails:
+        return ClientApplicationDetails(
+            client_id=client_id,
+            application_id="00000000-0000-0000-0000-000000000001",
+            application_name="Mocked Test Application",
+        )
 
 
 class MockedAppAndContext:
@@ -449,6 +457,7 @@ def make_context() -> util.Context:
 
 def make_access_token_payload(
     subject: str = "some_subject",
+    client_id: str = "some_client",
     audience: str = "some_audience",
     scopes: str = "some_scope",
     expiry_delta: int = 3600,
@@ -459,6 +468,8 @@ def make_access_token_payload(
     ----------
     subject : str, optional
         Subject for the claim, by default "some_subject"
+    client_id : str, optional
+        Client id for the claim, by default "some_client"
     audience : str, optional
         Audience for the claim, by default "some_audience"
     scope : str, optional
@@ -472,6 +483,7 @@ def make_access_token_payload(
     """
     return {
         "sub": subject,
+        "client_id": client_id,
         "iatiRegistryId": subject,  # for the automated tests, set these to the same
         "name": "some_user_name",
         "aud": audience,


### PR DESCRIPTION
This PR adds functionality to send three custom HTTP headers (used for auditing purposes) to SuiteCRM whenever a write-request is made.