### PR TITLE
Fix endpoints to remove trailing slashes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "register-your-data-api"
-version = "0.2.1"
+version = "0.2.2"
 requires-python = ">= 3.12.11"
 readme = "README.md"
 authors = [{name="IATI Secretariat", email="support@iatistandard.org"}]

--- a/src/main.py
+++ b/src/main.py
@@ -37,6 +37,6 @@ def add_routers_and_general_exception_handling(app: FastAPI) -> None:
     register_your_data_api.exceptions.add_exception_handlers(app)
 
 
-app = FastAPI(title="Register Your Data", lifespan=prod_lifespan)
+app = FastAPI(title="Register Your Data", lifespan=prod_lifespan, redirect_slashes=False)
 
 add_routers_and_general_exception_handling(app)

--- a/src/register_your_data_api/routers/datasets.py
+++ b/src/register_your_data_api/routers/datasets.py
@@ -30,7 +30,7 @@ from ..utilities import assert_precondition_met, check_crm_record_exists
 router = fastapi.APIRouter(prefix="/api/v1/datasets")
 
 
-@router.post("/")
+@router.post("")
 def create_dataset(
     request: starlette.requests.Request,
     dataset: DatasetCreateModel,

--- a/src/register_your_data_api/routers/discoverable_reporting_orgs.py
+++ b/src/register_your_data_api/routers/discoverable_reporting_orgs.py
@@ -21,7 +21,7 @@ from ..util import Context
 router = fastapi.APIRouter(prefix="/api/v1/discoverable-reporting-orgs")
 
 
-@router.get("/")
+@router.get("")
 def get_discoverable_reporting_orgs(
     request: starlette.requests.Request,
     user: auth_models.UserAndCredentials = Security(authz.get_user_authnz, scopes=["ryd", "ryd:reporting_org"]),

--- a/src/register_your_data_api/routers/reporting_orgs.py
+++ b/src/register_your_data_api/routers/reporting_orgs.py
@@ -45,7 +45,7 @@ from ..utilities import assert_precondition_met, check_crm_record_exists, perfor
 router = fastapi.APIRouter(prefix="/api/v1/reporting-orgs")
 
 
-@router.get("/")
+@router.get("")
 def get_reporting_orgs(
     request: starlette.requests.Request,
     user: auth_models.UserAndCredentials = Security(authz.get_user_authnz, scopes=["ryd", "ryd:reporting_org"]),
@@ -156,7 +156,7 @@ def get_reporting_org_detail(
     return UserReportingOrgRelationSingleResponse(status="success", error=None, data=user_reporting_org_relation)
 
 
-@router.post("/", status_code=201)
+@router.post("", status_code=201)
 def create_reporting_org(
     request: starlette.requests.Request,
     reporting_org: ReportingOrgUserCreateModel,


### PR DESCRIPTION
This PR:
* Brings the app in line with the spec, which does not have trailing slashes on any of the endpoints.
 * Disables auto-redirect for URLs with/without slashes. When enabled, if the endpoint were specified with '/', it would redirect URLs without the slash to one with the '/', and vice versa. But because neither the Apache reverse proxy nor uvicorn are setup to allow this forwarding for SSL connections, the redirect would drop authorisation. For now, disable this.

We will need to ping YI when we deploy this.