### PR TITLE
Create reporting orgs as discoverable, validate dataset, reporting_org `short_name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+ - Validation of dataset, reporting_org short_name to alphanumeric, '-', '_' chars
+ - On record creation, check dataset, reporting_org short_name for uniqueness
+
 ### Changed
 
 ### Deprecated
 
 ### Fixed
+
+ - Ensured that newly created reporting orgs are made discoverable on the Registry.
 
 ### Removed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "register-your-data-api"
-version = "0.2.2"
+version = "0.2.3"
 requires-python = ">= 3.12.11"
 readme = "README.md"
 authors = [{name="IATI Secretariat", email="support@iatistandard.org"}]

--- a/src/register_your_data_api/data_handling/data_schemas.py
+++ b/src/register_your_data_api/data_handling/data_schemas.py
@@ -80,7 +80,7 @@ class DatasetReadModel(pydantic.BaseModel):
 
 
 class ReportingOrgUserCreateModel(pydantic.BaseModel):
-    """Class for the data which comes from a POST to /reporting-orgs to create an org"""
+    """Class for the data which comes from a user's POST request to /reporting-orgs to create an org"""
 
     address: str | None
     contact_email: str = pydantic.Field(min_length=3)
@@ -101,7 +101,7 @@ class ReportingOrgUserCreateModel(pydantic.BaseModel):
 
 
 class ReportingOrgCreateModel(ReportingOrgUserCreateModel):
-    """Class for the data which comes from a POST to /reporting-orgs to create an org"""
+    """Class for the data which supplements a user's POST request to /reporting-orgs to create an org"""
 
     iati_registry_discoverable: str = "1"
 

--- a/src/register_your_data_api/data_handling/data_schemas.py
+++ b/src/register_your_data_api/data_handling/data_schemas.py
@@ -105,7 +105,7 @@ class ReportingOrgUserCreateModel(pydantic.BaseModel):
     phone: str | None
     region: str | None
     reporting_source_type: str | None
-    short_name: str | None
+    short_name: Annotated[str, pydantic.AfterValidator(validate_alpha_numeric_hyphen_str)]
     website: str | None
 
 

--- a/src/register_your_data_api/data_handling/data_schemas.py
+++ b/src/register_your_data_api/data_handling/data_schemas.py
@@ -1,6 +1,15 @@
-from typing import Literal
+import re
+from typing import Annotated, Literal
 
 import pydantic
+
+alpha_numeric_hyphen_regex = re.compile(r"^[a-zA-Z0-9-_]+$")
+
+
+def validate_alpha_numeric_hyphen_str(value: str) -> str:
+    if not alpha_numeric_hyphen_regex.match(value):
+        raise ValueError("String must contain only alphanumeric characters, hyphens, or underscores")
+    return value
 
 
 class BaseResponse(pydantic.BaseModel):
@@ -47,7 +56,7 @@ class DatasetCreateModel(pydantic.BaseModel):
     human_readable_name: str
     licence_id: str
     owner_organisation_id: str
-    short_name: str
+    short_name: Annotated[str, pydantic.AfterValidator(validate_alpha_numeric_hyphen_str)]
     source_type: str
     url: str
     visibility: str

--- a/src/register_your_data_api/routers/datasets.py
+++ b/src/register_your_data_api/routers/datasets.py
@@ -25,7 +25,7 @@ from ..data_handling.data_schemas import (
     DatasetUpdateModel,
 )
 from ..util import Context
-from ..utilities import assert_precondition_met, check_crm_record_exists
+from ..utilities import assert_precondition_met, check_crm_record_exists, get_num_crm_records
 
 router = fastapi.APIRouter(prefix="/api/v1/datasets")
 
@@ -42,24 +42,52 @@ def create_dataset(
 
     crm: SuiteCRM = context.suitecrm_client_factory.get_client()
 
-    if not user.validator.user_can_create_reporting_org_datasets(uuid.UUID(dataset.owner_organisation_id)):
-        context.audit_logger.error(
+    # Check the user has permission to create datasets for the specified
+    # reporting org
+    assert_precondition_met(
+        context,
+        condition_func=lambda: user.validator.user_can_create_reporting_org_datasets(
+            uuid.UUID(dataset.owner_organisation_id)
+        ),
+        status_code=fastapi.status.HTTP_403_FORBIDDEN,
+        audit_log_msg=(
             f"Request to create dataset for reporting org id: {dataset.owner_organisation_id} "
             f"by unauthorised user id: {user.user_id_crm}"
-        )
-        raise HTTPException(
-            status_code=fastapi.status.HTTP_403_FORBIDDEN,
-            detail="There is a problem with your credentials.  If this persists please report "
-            "error to the provider of the tool you are using to access the IATI Registry.",
-        )
+        ),
+        public_msg=(
+            "There is a problem with your credentials. If this persists please report this "
+            "error to the provider of the tool you are using to access the IATI Registry."
+        ),
+    )
 
-    # Permission to create datasets for a reporting org does not imply that the reporting org
-    # for superadmins, so we still check the reporting org exists
-    if not check_crm_record_exists(crm, "Accounts", str(dataset.owner_organisation_id)):
-        raise HTTPException(
-            status_code=fastapi.status.HTTP_404_NOT_FOUND,
-            detail=f"There is no organisation with ID {str(dataset.owner_organisation_id)} in the Registry.",
-        )
+    # Although most permissions as assocaited with reporting orgs, this is not
+    # the case for superadmins, so permission to create datasets for a reporting
+    # org does not imply that the reporting org exists, so we check that here
+    assert_precondition_met(
+        context,
+        condition_func=lambda: check_crm_record_exists(crm, "Accounts", str(dataset.owner_organisation_id)),
+        status_code=fastapi.status.HTTP_404_NOT_FOUND,
+        audit_log_msg=(
+            f"Request to create dataset for non-existent reporting org id: {dataset.owner_organisation_id} "
+            f"by user id: {user.user_id_crm}"
+        ),
+        public_msg=(f"There is no organisation with ID {str(dataset.owner_organisation_id)} in the Registry."),
+    )
+
+    # Check that the short name is unique
+    assert_precondition_met(
+        context,
+        condition_func=lambda: get_num_crm_records(crm, "IATI_Datasets", "iati_short_name", dataset.short_name) == 0,
+        status_code=fastapi.status.HTTP_409_CONFLICT,
+        audit_log_msg=(
+            f"Request to create dataset for reporting org id: {dataset.owner_organisation_id} by user id: "
+            f"{user.user_id_crm} with non-unique short name: {dataset.short_name}"
+        ),
+        public_msg=(
+            "Unable to create dataset as there is already a dataset with short_name "
+            f"'{dataset.short_name}' in the Registry."
+        ),
+    )
 
     # Create the record on SuiteCRM to add the dataset
     dataset_for_suitecrm = get_suitecrm_dict_from_dataset(dataset)

--- a/src/register_your_data_api/routers/reporting_orgs.py
+++ b/src/register_your_data_api/routers/reporting_orgs.py
@@ -41,7 +41,7 @@ from ..data_handling.data_schemas import (
 )
 from ..response_schemas import PaginatedResultsPage
 from ..util import Context
-from ..utilities import assert_precondition_met, check_crm_record_exists, perform_undo_actions
+from ..utilities import assert_precondition_met, check_crm_record_exists, get_num_crm_records, perform_undo_actions
 
 router = fastapi.APIRouter(prefix="/api/v1/reporting-orgs")
 
@@ -169,17 +169,35 @@ def create_reporting_org(
 
     context: Context = request.app.state.context
 
-    if not user.validator.user_can_create_reporting_org():
-        context.audit_logger.error(f"Request to create reporting org by unauthorised user id: {user.user_id_crm}")
-        raise HTTPException(
-            status_code=fastapi.status.HTTP_403_FORBIDDEN,
-            detail="There is a problem with your credentials.  If this persists please report "
-            "error to the provider of the tool you are using to access the IATI Registry.",
-        )
+    assert_precondition_met(
+        context,
+        condition_func=lambda: user.validator.user_can_create_reporting_org(),
+        status_code=fastapi.status.HTTP_403_FORBIDDEN,
+        audit_log_msg=(f"Request to create reporting org by unauthorised user id: {user.user_id_crm}"),
+        public_msg=(
+            "There is a problem with your credentials.  If this persists please report "
+            "error to the provider of the tool you are using to access the IATI Registry."
+        ),
+    )
 
     undo_actions: list[tuple[str, Callable[[], Any]]] = []
 
     crm: SuiteCRM = context.suitecrm_client_factory.get_client()
+
+    # Check that the short name is unique
+    assert_precondition_met(
+        context,
+        condition_func=lambda: get_num_crm_records(crm, "Accounts", "iati_short_name", reporting_org.short_name) == 0,
+        status_code=fastapi.status.HTTP_409_CONFLICT,
+        audit_log_msg=(
+            f"Request to create reporting org by user id: {user.user_id_crm} "
+            f"with non-unique short name: {reporting_org.short_name}"
+        ),
+        public_msg=(
+            "Unable to create reporting org as there is already a reporting org with short_name "
+            f"'{reporting_org.short_name}' in the Registry."
+        ),
+    )
 
     try:
         # 1. Create the reporting on SuiteCRM

--- a/src/register_your_data_api/routers/reporting_orgs.py
+++ b/src/register_your_data_api/routers/reporting_orgs.py
@@ -30,6 +30,7 @@ from ..data_handling.data_schemas import (
     DiscoverableReportingOrgMetadata,
     PaginationQueryParams,
     ReportingOrgAction,
+    ReportingOrgCreateModel,
     ReportingOrgMetadata,
     ReportingOrgUpdateModel,
     ReportingOrgUserCreateModel,
@@ -182,7 +183,8 @@ def create_reporting_org(
 
     try:
         # 1. Create the reporting on SuiteCRM
-        reporting_org_for_suitecrm = get_suitecrm_dict_from_reporting_org(reporting_org)
+        reporting_org_to_create = ReportingOrgCreateModel(**reporting_org.model_dump())
+        reporting_org_for_suitecrm = get_suitecrm_dict_from_reporting_org(reporting_org_to_create)
         suitecrm_reporting_org = crm.create_record(
             "Accounts", reporting_org_for_suitecrm, headers=suitecrm_audit_headers
         )

--- a/src/register_your_data_api/utilities.py
+++ b/src/register_your_data_api/utilities.py
@@ -84,6 +84,29 @@ def check_crm_record_exists(crm: SuiteCRM, module: str, id: str) -> bool:
     return "data" in results and len(results["data"]) == 1
 
 
+def get_num_crm_records(crm: SuiteCRM, module: str, field: str, value: str) -> int:
+    """Gets the number of records from a specified module matching the criterion specified
+
+    Parameters
+    ----------
+    module : str
+        The module name on SuiteCRM
+    field : str
+        The fieldname to check
+    value : str
+        The value the field should take
+
+    Returns
+    -------
+    int
+        The number of matching records
+    """
+    filters = Filter()
+    filters.equal(field, value)
+    results = crm.get_records(module, filters=filters, fields=["id"])
+    return len(results["data"]) if "data" in results else 0
+
+
 def perform_undo_actions(
     context: Context, undo_actions: list[tuple[str, Callable[[], Any]]], func_name: str
 ) -> uuid.UUID:

--- a/tests/helpers/mocked_objects/mock_suitecrm.py
+++ b/tests/helpers/mocked_objects/mock_suitecrm.py
@@ -92,6 +92,8 @@ class MockSuiteCRM:
                 "created_date": get_current_timestamp_as_str(),
                 "first_publication_date": "",
                 "registry_approved": "0",
+                "iati_url_update_date": "",
+                "iati_metadata_update_date": "",
                 **data,
             },
         }

--- a/tests/integration/test_dataset_routes.py
+++ b/tests/integration/test_dataset_routes.py
@@ -1,0 +1,48 @@
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ..helpers.mocking import MockedAppAndContext
+
+
+@pytest.mark.parametrize(
+    "invalid_short_name",
+    [
+        "invalid short name!",  # contains spaces and exclamation mark
+        "invalid@name",  # contains special character '@'
+        "name/with/slash",  # contains slash
+        "name\\with\\backslash",  # contains backslash
+        "name:with:colon",  # contains colon
+        "name*with*asterisk",  # contains asterisk
+        "name?with?question",  # contains question mark)
+    ],
+)
+def test_dataset_create_with_invalid_short_name(invalid_short_name: str) -> None:
+
+    appAndContext = MockedAppAndContext()
+
+    fastAPIapp = appAndContext.get_test_app()
+
+    new_dataset = {
+        "human_readable_name": "Test Dataset 01",
+        "licence_id": "cc-by",
+        "owner_organisation_id": "552376ae-2aa7-98ab-d800-68daa9bfeb4a",
+        "short_name": invalid_short_name,
+        "source_type": "primary_source",
+        "url": "http://www.example.com/dataset01",
+        "visibility": "private",
+    }
+
+    with TestClient(fastAPIapp) as client:
+        response = client.post(
+            "/api/v1/datasets",
+            headers=appAndContext.get_valid_authorization_header(0),
+            content=json.dumps(new_dataset),
+        )
+
+        assert response.status_code == 400
+
+        response_obj = json.loads(response.content)
+
+        assert response_obj["status"] == "failed"

--- a/tests/integration/test_reporting_org_routes.py
+++ b/tests/integration/test_reporting_org_routes.py
@@ -377,6 +377,57 @@ def test_reporting_org_create_with_missing_fields(user: int) -> None:
             assert response_obj["status"] == "failed"
 
 
+@pytest.mark.parametrize(
+    "invalid_short_name",
+    [
+        "invalid short name!",  # contains spaces and exclamation mark
+        "invalid@name",  # contains special character '@'
+        "name/with/slash",  # contains slash
+        "name\\with\\backslash",  # contains backslash
+        "name:with:colon",  # contains colon
+        "name*with*asterisk",  # contains asterisk
+        "name?with?question",  # contains question mark)
+    ],
+)
+def test_reporting_org_create_with_invalid_short_name(invalid_short_name: str) -> None:
+
+    appAndContext = MockedAppAndContext()
+
+    fastAPIapp = appAndContext.get_test_app()
+
+    new_reporting_org = {
+        "address": "Fake Address",
+        "contact_email": "org.admin@example.org",
+        "data_portal_url": "https://www.example.org/data-portal",
+        "default_licence_id": "gpl-3.0",
+        "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+        "exclusions_policy_url": "https://www.example.org/exclusions-policy",
+        "fax": "456-7890-1234",
+        "hq_country": "CO",
+        "human_readable_name": "Aid Agency",
+        "organisation_identifier": "CO-ABC-123456",
+        "organisation_type": "Regional NGO",
+        "phone": "123-4567-8901",
+        "region": "489",
+        "reporting_source_type": "primary_source",
+        "short_name": invalid_short_name,
+        "website": "https://www.example.org/",
+    }
+
+    with TestClient(fastAPIapp) as client:
+        response = client.post(
+            "/api/v1/reporting-orgs/",
+            headers=appAndContext.get_valid_authorization_header(0),
+            content=json.dumps(new_reporting_org),
+        )
+
+        assert response.status_code == 400
+
+        response_obj = json.loads(response.content)
+
+        assert response_obj["status"] == "failed"
+
+
 @pytest.mark.parametrize("user,status_code", [(0, 403), (1, 200), (2, 200), (3, 403), (4, 403)])
 def test_reporting_org_delete(user: int, status_code: int) -> None:
     appAndContext = MockedAppAndContext()


### PR DESCRIPTION
This PR:
* Fixes the creation of reporting orgs so that `iati_registry_discoverable` is set to 1
* Adds string validation (alphanumeric, plus '-' and '_') to the dataset, reporting_org `short_name` field
* Adds validation on the creation of datasets, reporting orgs to check that the `short_name` is unique. (If not, 409 `Conflict` is returned - API spec will be updated for this).

This closes #42 and #43.