### PR TITLE
Make the check CRM record exists function more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
- - Dataset actions returned on /dataset/{id} and /reporting-orgs/{id}/dataset
-   endpoints.
-
 ### Changed
 
 ### Deprecated
@@ -22,6 +19,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.2.5]
+
+### Fixed
+
+ - Made the utility check_record_exists function more robust by limiting fields
+   returned.
+
+### Removed
+
+### Security
+
+## [0.2.4]
+
+### Added
+
+ - Dataset actions returned on /dataset/{id} and /reporting-orgs/{id}/dataset
+   endpoints.
 
 ## [0.2.3] - 2025-12-08
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "register-your-data-api"
-version = "0.2.4"
+version = "0.2.5"
 requires-python = ">= 3.12.11"
 readme = "README.md"
 authors = [{name="IATI Secretariat", email="support@iatistandard.org"}]

--- a/src/register_your_data_api/utilities.py
+++ b/src/register_your_data_api/utilities.py
@@ -80,7 +80,7 @@ def check_crm_record_exists(crm: SuiteCRM, module: str, id: str) -> bool:
     """
     filters = Filter()
     filters.equal("id", id)
-    results = crm.get_records(module, filters=filters, fields=[])
+    results = crm.get_records(module, filters=filters, fields=["id"])
     return "data" in results and len(results["data"]) == 1
 
 


### PR DESCRIPTION
When requesting records by id, SuiteCRM sometimes returns the same record twice, with very minor differences on (I think) some of the link/relationship fields. This caused this existence check to fail. By limiting the fields we request from SuiteCRM, this stops that happening (at least in the instances I've checked).

This will resolve https://github.com/IATI/register-your-data-api/issues/52

NOTE: This PR is compared against the `sk-fetch-and-return-dataset-actions` branch, so that needs doing first, then this one can be rebased and merged, if approved. 