### PR TITLE
Fix dataset `short_name` validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.2.7]
+
+### Fixed
+
+ - Fixed the dataset PATCH endpoint to include validation of the dataset
+   short_name field.
+
 ## [0.2.6]
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "register-your-data-api"
-version = "0.2.6"
+version = "0.2.7"
 requires-python = ">= 3.12.11"
 readme = "README.md"
 authors = [{name="IATI Secretariat", email="support@iatistandard.org"}]

--- a/src/register_your_data_api/data_handling/data_schemas.py
+++ b/src/register_your_data_api/data_handling/data_schemas.py
@@ -65,7 +65,7 @@ class DatasetCreateModel(pydantic.BaseModel):
 class DatasetUpdateModel(pydantic.BaseModel):
     human_readable_name: str
     licence_id: str
-    short_name: str
+    short_name: Annotated[str, pydantic.AfterValidator(validate_alpha_numeric_hyphen_str)]
     source_type: str
     url: str
     visibility: Literal["public", "private"] | None = None

--- a/src/register_your_data_api/routers/datasets.py
+++ b/src/register_your_data_api/routers/datasets.py
@@ -172,45 +172,58 @@ def update_dataset(
     ds_filters = Filter()
     ds_filters.equal("id", str(dataset_id))
     original_dataset_record_from_suitecrm = crm.get_records(
-        "IATI_Datasets", fields=["iati_dataset_owner_org_id", "iati_visibility"], filters=ds_filters
+        "IATI_Datasets", fields=["iati_dataset_owner_org_id", "iati_short_name", "iati_visibility"], filters=ds_filters
     )
 
-    if len(original_dataset_record_from_suitecrm["data"]) == 0:
-        raise HTTPException(
-            status_code=fastapi.status.HTTP_404_NOT_FOUND,
-            detail=f"There is no dataset with ID {str(dataset_id)} in the Registry.",
-        )
+    assert_precondition_met(
+        context,
+        condition_func=lambda: len(original_dataset_record_from_suitecrm["data"]) != 0,
+        status_code=fastapi.status.HTTP_404_NOT_FOUND,
+        audit_log_msg=(
+            f"user id: {user.user_id_crm} - PATCH /datasets/ID - request to update dataset id: "  # nosec B608
+            f"{str(dataset_id)} but there is no dataset with that ID in the Registry"
+        ),
+        public_msg=(
+            f"Error: cannot update dataset with {str(dataset_id)} as there is no dataset with that ID."  # nosec B608
+        ),
+    )
 
     owning_reporting_org = original_dataset_record_from_suitecrm["data"][0]["attributes"]["iati_dataset_owner_org_id"]
 
-    if not user.validator.user_can_update_reporting_org_datasets(uuid.UUID(owning_reporting_org)):
-        context.audit_logger.error(
-            f"Request to update dataset for reporting org id: {owning_reporting_org} "  # nosec B608
-            f"by unauthorised user id: {user.user_id_crm}"
-        )
-        raise HTTPException(
-            status_code=fastapi.status.HTTP_403_FORBIDDEN,
-            detail="There is a problem with your credentials.  If this persists please report "
-            "error to the provider of the tool you are using to access the IATI Registry.",
-        )
+    assert_precondition_met(
+        context,
+        condition_func=lambda: user.validator.user_can_update_reporting_org_datasets(uuid.UUID(owning_reporting_org)),
+        status_code=fastapi.status.HTTP_403_FORBIDDEN,
+        audit_log_msg=(
+            f"user id: {user.user_id_crm} - PATCH /datasets/ID - request to update dataset id: "  # nosec B608
+            f"{str(dataset_id)} belonging to reporting org id: {owning_reporting_org} by unauthorised user"
+        ),
+        public_msg=(
+            "There is a problem with your credentials. If this persists please report "
+            "error to the provider of the tool you are using to access the IATI Registry."
+        ),
+    )
 
-    # Create the record on SuiteCRM to add the dataset
+    # Create the SuiteCRM-structured record to update the dataset
     dataset_for_suitecrm = get_suitecrm_dict_from_dataset(dataset)
 
-    if (
-        not user.validator.user_can_update_reporting_org_dataset_visibility(owning_reporting_org)
-        and dataset.visibility is not None
-        and original_dataset_record_from_suitecrm["data"][0]["attributes"]["iati_visibility"] != dataset.visibility
-    ):
-        context.audit_logger.error(
-            f"Request to update dataset visibility for reporting org id: {owning_reporting_org} "  # nosec B608
-            f"by user id: {user.user_id_crm} authorised to update dataset but not dataset visibility "
-        )
-        raise HTTPException(
-            status_code=fastapi.status.HTTP_403_FORBIDDEN,
-            detail="There is a problem with your credentials.  If this persists please report "
-            "error to the provider of the tool you are using to access the IATI Registry.",
-        )
+    assert_precondition_met(
+        context,
+        condition_func=lambda: (
+            user.validator.user_can_update_reporting_org_dataset_visibility(owning_reporting_org)
+            or dataset.visibility is None
+            or original_dataset_record_from_suitecrm["data"][0]["attributes"]["iati_visibility"] == dataset.visibility
+        ),
+        status_code=fastapi.status.HTTP_403_FORBIDDEN,
+        audit_log_msg=(
+            f"user id: {user.user_id_crm} - PATCH /datasets/ID - request to update visibility for "  # nosec B608
+            f"dataset id: {str(dataset_id)} belonging to reporting org id: {owning_reporting_org} by unauthorised user"
+        ),
+        public_msg=(
+            "There is a problem with your credentials. If this persists please report "
+            "error to the provider of the tool you are using to access the IATI Registry."
+        ),
+    )
 
     if dataset.visibility is None:
         dataset_for_suitecrm.pop("iati_visibility", None)

--- a/src/register_your_data_api/routers/datasets.py
+++ b/src/register_your_data_api/routers/datasets.py
@@ -228,6 +228,28 @@ def update_dataset(
     if dataset.visibility is None:
         dataset_for_suitecrm.pop("iati_visibility", None)
 
+    # Check that the short name is unique
+    assert_precondition_met(
+        context,
+        condition_func=lambda: (
+            original_dataset_record_from_suitecrm["data"][0]["attributes"]["iati_short_name"] == dataset.short_name
+            or (
+                original_dataset_record_from_suitecrm["data"][0]["attributes"]["iati_short_name"] != dataset.short_name
+                and get_num_crm_records(crm, "IATI_Datasets", "iati_short_name", dataset.short_name) == 0
+            )
+        ),
+        status_code=fastapi.status.HTTP_409_CONFLICT,
+        audit_log_msg=(
+            f"user id: {user.user_id_crm} - PATCH /datasets/ID - request to update short_name for dataset id: "
+            f"{str(dataset_id)} belonging to reporting org id: {owning_reporting_org} but there is already a dataset "
+            f"with short_name '{dataset.short_name}' in the Registry"  # nosec B608
+        ),
+        public_msg=(
+            "Error: unable to update dataset as there is already a dataset with short_name "  # nosec B608
+            f"'{dataset.short_name}' in the Registry."
+        ),
+    )
+
     suitecrm_dataset = crm.update_record(
         "IATI_Datasets", str(dataset_id), dataset_for_suitecrm, headers=suitecrm_audit_headers
     )

--- a/tests/integration/test_dataset_routes.py
+++ b/tests/integration/test_dataset_routes.py
@@ -46,3 +46,59 @@ def test_dataset_create_with_invalid_short_name(invalid_short_name: str) -> None
         response_obj = json.loads(response.content)
 
         assert response_obj["status"] == "failed"
+
+
+@pytest.mark.parametrize(
+    "invalid_short_name",
+    [
+        "invalid short name!",  # contains spaces and exclamation mark
+        "invalid@name",  # contains special character '@'
+        "name/with/slash",  # contains slash
+        "name\\with\\backslash",  # contains backslash
+        "name:with:colon",  # contains colon
+        "name*with*asterisk",  # contains asterisk
+        "name?with?question",  # contains question mark)
+    ],
+)
+def test_dataset_update_with_invalid_short_name(invalid_short_name: str) -> None:
+
+    appAndContext = MockedAppAndContext()
+
+    fastAPIapp = appAndContext.get_test_app()
+
+    dataset = {
+        "human_readable_name": "Test Dataset 01",
+        "licence_id": "cc-by",
+        "owner_organisation_id": "552376ae-2aa7-98ab-d800-68daa9bfeb4a",
+        "short_name": "valid_dataset_short_name",
+        "source_type": "primary_source",
+        "url": "http://www.example.com/dataset01",
+        "visibility": "private",
+    }
+
+    with TestClient(fastAPIapp) as client:
+        auth_header = appAndContext.get_valid_authorization_header(0)
+
+        response_create = client.post(
+            "/api/v1/datasets",
+            headers=auth_header,
+            content=json.dumps(dataset),
+        )
+
+        assert response_create.status_code == 200
+
+        resp_create_obj = response_create.json()
+
+        dataset["short_name"] = invalid_short_name
+
+        response_update = client.patch(
+            f"/api/v1/datasets/{resp_create_obj["data"]["id"]}",
+            headers=auth_header,
+            content=json.dumps(dataset),
+        )
+
+        assert response_update.status_code == 400
+
+        response_obj = response_update.json()
+
+        assert response_obj["status"] == "failed"


### PR DESCRIPTION
This PR adds to the PATCH dataset endpoint:
* Refactors the PATCH method to use the new `assert_precondition_met` method
* Adds string validation for the short_name field (previously any string was permitted)
* Verifies that the new `short_name` (if it's been updated) is unique in the Registry

This will resolve https://github.com/IATI/register-your-data-api/issues/57

