### PR TITLE
Send email notifications; adds more audit and error logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,49 @@
-JWKS_URI = "https://example.org/jwks"
 APP_LOG_LEVEL = "DEBUG"
 APP_LOG_PATH = "/path/to/log/file/log.txt"
 AUDIT_LOG_PATH = "/path/to/audit/log/file/log.txt"
 AUDIT_LOG_PUBLIC_KEY_PATH = "/path/to/audit/log/public_key/keyfile.pem"
+
+AZURE_COMMUNICATION_SERVICE_CONNECTION_STRING=""
+
+# This file is used to configure the client applications and their IDs. It should be a
+# JSON list of objects, each with the following keys:
+# - client_id
+# - application_id
+# - application_name
+# Example:
+# [
+#     {
+#         "client_id": "E8aUJURhPUrf3DiFxRsYKk3jjh7a",
+#         "application_id": "74916a90-718d-4cef-8da4-43863df11198",
+#         "application_name": "App Name"
+#     }
+# ]
+CLIENT_APPLICATION_DETAILS_FILE="path/to/client/applications/metadata/file.json"
+
+DATA_REGISTRY_SUITECRM_API_URL = "https://base_url_of_suitecrm_instance.org"
+
+DATA_REGISTRY_SUITECRM_CLIENT_ID = "RYD's client ID here"
+
+DATA_REGISTRY_SUITECRM_CLIENT_SECRET = "RYD's client secret here"
+
+EMAIL_ADDRESS_FOR_IATI_SUPPORT_APPROVALS="email_to_send_approvals_to@example.org"
+
+EMAIL_NEW_ORG_NOTIFICATION_ADDRESS=""
+
+EMAIL_SENDER_RYD_FROM_NAME=""
+
+EMAIL_SENDER_RYD_FROM_EMAIL=""
+
+EMAIL_TEMPLATES_DIR="email_templates"
+
+FGA_PROVIDER_CONNECTION_STRING="FGA database connection string here"
+
+FGA_PROVIDER=FineGrainedAuthorisationProviderPgDb
+
+IATI_ACCOUNT_INSTANCE_BASE_URL="https://BASE_URL_HERE"
+
 PROMETHEUS_PORT = 1111
+
+JWKS_URI = "https://example.org/jwks"
+
 JWT_AUDIENCE = "some_audience"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,6 @@ RUN pip install -e .
 
 COPY src/ src
 COPY alembic/ alembic
+COPY email_templates/ email_templates
 
 ENTRYPOINT ["fastapi", "run", "src/main.py", "--port", "8000"]

--- a/email_templates/new_org_needs_approval.html
+++ b/email_templates/new_org_needs_approval.html
@@ -1,0 +1,32 @@
+<p>
+Dear IATI Support Team,
+</p>
+<p>
+A new organisation has been created in the IATI Registry and requires approval.
+</p>
+<p>
+Organisation Details:
+<ul>
+<li>Organisation Short Name: {{ org_short_name }}</li>
+<li>Organisation Name: {{ org_human_readable_name }}</li>
+<li>Organisation ID: {{ org_id }}</li>
+<li>Organisation Page: <a href="{{ site_url }}/en/data/organisation/{{ org_id }}">{{ site_url }}/en/data/organisation/{{ org_id }}</a></li>
+</ul>
+</p>
+<p>
+Created by:
+<ul>
+<li>User Name: {{ user_name }}</li>
+<li>User Email: {{ user_email }}</li>
+<li>User ID: {{ user_id }}</li>
+</ul>
+</p>
+<p>
+Created on:
+<ul>
+<li>Date creation request made: {{ creation_date }}</li>
+</ul>
+</p>
+<p>
+Please review this organisation and approve or reject it as appropriate.
+</p>

--- a/email_templates/new_org_needs_approval.html
+++ b/email_templates/new_org_needs_approval.html
@@ -2,7 +2,7 @@
 Dear IATI Support Team,
 </p>
 <p>
-A new organisation has been created in the IATI Registry and requires approval.
+A new organisation has been created using Register Your Data and requires approval.
 </p>
 <p>
 Organisation Details:

--- a/email_templates/new_org_needs_approval.txt
+++ b/email_templates/new_org_needs_approval.txt
@@ -1,0 +1,16 @@
+Dear IATI Support Team,
+
+A new organisation has been created in the IATI Registry and requires approval.
+
+Organisation Details:
+- Organisation Short name: {{ org_short_name }}
+- Organisation Human readable name: {{ org_human_readable_name }}
+- Organisation ID: {{ org_id }}
+- Organisation Page: {{ site_url }}/en/data/organisation/{{ org_id }}
+
+Created by:
+- User Name: {{ user_name }}
+- User Email: {{ user_email }}
+- User ID: {{ user_id }}
+
+Please review this organisation and approve or reject it as appropriate.

--- a/email_templates/new_org_needs_approval.txt
+++ b/email_templates/new_org_needs_approval.txt
@@ -1,6 +1,6 @@
 Dear IATI Support Team,
 
-A new organisation has been created in the IATI Registry and requires approval.
+A new organisation has been created using Register Your Data and requires approval.
 
 Organisation Details:
 - Organisation Short name: {{ org_short_name }}

--- a/email_templates/new_org_needs_approval_subject.txt
+++ b/email_templates/new_org_needs_approval_subject.txt
@@ -1,0 +1,1 @@
+New organisation requires approval

--- a/email_templates/user_requested_to_join_org.html
+++ b/email_templates/user_requested_to_join_org.html
@@ -1,0 +1,23 @@
+<p>
+Dear {{ to_name }},
+</p>
+<p>
+A new user {{ user_requesting_join_name }}, with email address {{user_requesting_join_email }}, has requested to join your organisation {{ org_name }}.
+</p>
+
+<p>As an admin user for this organisation, please approve or reject this request in IATI Account.</p>
+
+<p>
+You can do this by:
+<ul>
+<li>Signing in to IATI Account: <a href="{{ site_url }}">{{ site_url }}</a></li>
+<li>Viewing your organisation: <a href="{{ site_url }}/en/data/organisation/{{ org_id }}"></a>{{ site_url }}/en/data/organisation/{{ org_id }}</a></li>
+<li>Navigating to the "Users" table at the bottom of your organisation’s page</li>
+<li>Changing the new user's role from 'CONTRIBUTOR' to one of 'ADMIN', 'EDITOR' or 'CONTRIBUTOR'.</li>
+</ul>
+</p>
+<p>If you do not recognise the new user, you can select to remove them from your organisation.</p>
+
+<p>Read more about managing users and role permissions in IATI Account here:
+<a href="https://docs.account.iatistandard.org/en/latest/manage_organisation_users/">https://docs.account.iatistandard.org/en/latest/manage_organisation_users/</a>
+</p>

--- a/email_templates/user_requested_to_join_org.html
+++ b/email_templates/user_requested_to_join_org.html
@@ -2,7 +2,7 @@
 Dear {{ to_name }},
 </p>
 <p>
-A new user {{ user_requesting_join_name }}, with email address {{user_requesting_join_email }}, has requested to join your organisation {{ org_name }}.
+A new user {{ user_requesting_join_name }}, with email address {{user_requesting_join_email }}, has requested to join your organisation {{ org_human_readable_name }}.
 </p>
 
 <p>As an admin user for this organisation, please approve or reject this request in IATI Account.</p>
@@ -13,7 +13,7 @@ You can do this by:
 <li>Signing in to IATI Account: <a href="{{ site_url }}">{{ site_url }}</a></li>
 <li>Viewing your organisation: <a href="{{ site_url }}/en/data/organisation/{{ org_id }}"></a>{{ site_url }}/en/data/organisation/{{ org_id }}</a></li>
 <li>Navigating to the "Users" table at the bottom of your organisation’s page</li>
-<li>Changing the new user's role from 'CONTRIBUTOR' to one of 'ADMIN', 'EDITOR' or 'CONTRIBUTOR'.</li>
+<li>Changing the new user's role to one of 'ADMIN', 'EDITOR' or 'CONTRIBUTOR'.</li>
 </ul>
 </p>
 <p>If you do not recognise the new user, you can select to remove them from your organisation.</p>

--- a/email_templates/user_requested_to_join_org.txt
+++ b/email_templates/user_requested_to_join_org.txt
@@ -1,0 +1,16 @@
+Dear {{ to_name }},
+
+A new user {{ user_requesting_join_name }}, with email address {{user_requesting_join_email }}, has requested to join your organisation {{ org_name }}.
+
+As an admin user for this organisation, please approve or reject this request in IATI Account.
+
+You can do this by:
+
+- Signing in to IATI Account: {{ site_url }}
+- Viewing your organisation: {{ site_url }}/en/data/organisation/{{ org_id }}
+- Navigating to the "Users" table at the bottom of your organisation's page
+- Changing the new user's role from 'CONTRIBUTOR' to one of 'ADMIN', 'EDITOR' or 'CONTRIBUTOR'.
+
+If you do not recognise the new user, you can select to remove them from your organisation.
+
+Read more about managing users and role permissions in IATI Account here: https://docs.account.iatistandard.org/en/latest/manage_organisation_users/

--- a/email_templates/user_requested_to_join_org.txt
+++ b/email_templates/user_requested_to_join_org.txt
@@ -1,6 +1,6 @@
 Dear {{ to_name }},
 
-A new user {{ user_requesting_join_name }}, with email address {{user_requesting_join_email }}, has requested to join your organisation {{ org_name }}.
+A new user {{ user_requesting_join_name }}, with email address {{user_requesting_join_email }}, has requested to join your organisation {{ org_human_readable_name }}.
 
 As an admin user for this organisation, please approve or reject this request in IATI Account.
 
@@ -9,7 +9,7 @@ You can do this by:
 - Signing in to IATI Account: {{ site_url }}
 - Viewing your organisation: {{ site_url }}/en/data/organisation/{{ org_id }}
 - Navigating to the "Users" table at the bottom of your organisation's page
-- Changing the new user's role from 'CONTRIBUTOR' to one of 'ADMIN', 'EDITOR' or 'CONTRIBUTOR'.
+- Changing the new user's role to one of 'ADMIN', 'EDITOR' or 'CONTRIBUTOR'.
 
 If you do not recognise the new user, you can select to remove them from your organisation.
 

--- a/email_templates/user_requested_to_join_org_subject.txt
+++ b/email_templates/user_requested_to_join_org_subject.txt
@@ -1,0 +1,1 @@
+Approve a new user for your organisation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ dev = [
     "isort",
     "mypy",
     "pip-tools",
-    "pytest"
+    "pytest",
+    "pytest-watcher>=0.6.0,<1.0.0"
 ]
 
 [tool.alembic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "azure-communication-email>=1.0.0,<2.0.0",
     "click",
     "cryptography==45.0.5",
+    "email_validator>=2.3.0,<3.0.0",    
     "fastapi[standard]==0.116.0",
     "jinja2>=3.1.6,<4.0.0",
     "libsuitecrm @ git+https://github.com/iati/iati-registry-libsuitecrm@v0.5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "register-your-data-api"
-version = "0.2.8"
+version = "0.2.9"
 requires-python = ">= 3.12.11"
 readme = "README.md"
 authors = [{name="IATI Secretariat", email="support@iatistandard.org"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = "API for writing to the IATI Registry"
 
 dependencies = [
     "alembic",
+    "azure-communication-email>=1.0.0,<2.0.0",
     "click",
     "cryptography==45.0.5",
     "fastapi[standard]==0.116.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "click",
     "cryptography==45.0.5",
     "fastapi[standard]==0.116.0",
+    "jinja2>=3.1.6,<4.0.0",
     "libsuitecrm @ git+https://github.com/iati/iati-registry-libsuitecrm@v0.5.0",
     "prometheus-client>=0.22.1",
     "pyjwt>=2.10.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,10 +37,11 @@ cryptography==45.0.5
     # via register-your-data-api (pyproject.toml)
 dnspython==2.7.0
     # via email-validator
-email-validator==2.2.0
+email-validator==2.3.0
     # via
     #   fastapi
     #   pydantic
+    #   register-your-data-api (pyproject.toml)
 fastapi==0.116.0
     # via register-your-data-api (pyproject.toml)
 fastapi-cli==0.0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,10 @@ anyio==4.9.0
     #   httpx
     #   starlette
     #   watchfiles
+azure-communication-email==1.1.0
+    # via register-your-data-api (pyproject.toml)
+azure-core==1.38.0
+    # via azure-communication-email
 certifi==2025.6.15
     # via
     #   httpcore
@@ -63,6 +67,8 @@ idna==3.10
     #   email-validator
     #   httpx
     #   requests
+isodate==0.7.2
+    # via azure-communication-email
 jinja2==3.1.6
     # via
     #   fastapi
@@ -112,6 +118,7 @@ pyyaml==6.0.2
     # via uvicorn
 requests==2.32.4
     # via
+    #   azure-core
     #   libsuitecrm
     #   register-your-data-api (pyproject.toml)
     #   requests-oauthlib
@@ -152,6 +159,8 @@ typing-extensions==4.14.1
     # via
     #   alembic
     #   anyio
+    #   azure-communication-email
+    #   azure-core
     #   fastapi
     #   psycopg
     #   pydantic

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,7 +64,9 @@ idna==3.10
     #   httpx
     #   requests
 jinja2==3.1.6
-    # via fastapi
+    # via
+    #   fastapi
+    #   register-your-data-api (pyproject.toml)
 libsuitecrm @ git+https://github.com/iati/iati-registry-libsuitecrm@v0.5.0
     # via register-your-data-api (pyproject.toml)
 mako==1.3.10

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -45,10 +45,11 @@ cryptography==45.0.5
     # via register-your-data-api (pyproject.toml)
 dnspython==2.7.0
     # via email-validator
-email-validator==2.2.0
+email-validator==2.3.0
     # via
     #   fastapi
     #   pydantic
+    #   register-your-data-api (pyproject.toml)
 fastapi==0.116.0
     # via register-your-data-api (pyproject.toml)
 fastapi-cli==0.0.8

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -86,7 +86,9 @@ iniconfig==2.1.0
 isort==6.0.1
     # via register-your-data-api (pyproject.toml)
 jinja2==3.1.6
-    # via fastapi
+    # via
+    #   fastapi
+    #   register-your-data-api (pyproject.toml)
 libsuitecrm @ git+https://github.com/iati/iati-registry-libsuitecrm@v0.5.0
     # via register-your-data-api (pyproject.toml)
 mako==1.3.10

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -161,6 +161,8 @@ pyproject-hooks==1.2.0
     #   pip-tools
 pytest==8.4.1
     # via register-your-data-api (pyproject.toml)
+pytest-watcher==0.6.3
+    # via register-your-data-api (pyproject.toml)
 python-dotenv==1.1.1
     # via
     #   register-your-data-api (pyproject.toml)
@@ -241,6 +243,8 @@ uvicorn==0.35.0
     #   fastapi-cloud-cli
 uvloop==0.21.0
     # via uvicorn
+watchdog==6.0.0
+    # via pytest-watcher
 watchfiles==1.1.0
     # via uvicorn
 websockets==15.0.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,6 +13,10 @@ anyio==4.9.0
     #   httpx
     #   starlette
     #   watchfiles
+azure-communication-email==1.1.0
+    # via register-your-data-api (pyproject.toml)
+azure-core==1.38.0
+    # via azure-communication-email
 bandit==1.8.6
     # via register-your-data-api (pyproject.toml)
 black==25.1.0
@@ -83,6 +87,8 @@ idna==3.10
     #   requests
 iniconfig==2.1.0
     # via pytest
+isodate==0.7.2
+    # via azure-communication-email
 isort==6.0.1
     # via register-your-data-api (pyproject.toml)
 jinja2==3.1.6
@@ -175,6 +181,7 @@ pyyaml==6.0.2
     #   uvicorn
 requests==2.32.4
     # via
+    #   azure-core
     #   libsuitecrm
     #   register-your-data-api (pyproject.toml)
     #   requests-oauthlib
@@ -220,6 +227,8 @@ typing-extensions==4.14.1
     # via
     #   alembic
     #   anyio
+    #   azure-communication-email
+    #   azure-core
     #   fastapi
     #   mypy
     #   psycopg

--- a/src/audit_log_viewer.py
+++ b/src/audit_log_viewer.py
@@ -108,7 +108,7 @@ def main(use_stdin: bool) -> None:
     context = AuditLogViewerContext(use_stdin, audit_log_path, audit_log_private_key_path)
 
     for line in decrypt_audit_log(context):
-        print(line)
+        print(line, flush=True)
 
 
 if __name__ == "__main__":

--- a/src/register_your_data_api/auth/fga/fga_provider.py
+++ b/src/register_your_data_api/auth/fga/fga_provider.py
@@ -26,6 +26,11 @@ class FineGrainedAuthorisationProvider(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def get_admin_users_for_org(self, org: UUID) -> list[FineGrainedAuthorisationRoleAssociation]:
+        """Returns a list of all the admin users for a specific organisation"""
+        raise NotImplementedError
+
+    @abstractmethod
     def is_user_a_superadmin(self, user: UUID) -> bool:
         """Returns True if the user is a superadmin, else False"""
         raise NotImplementedError

--- a/src/register_your_data_api/auth/fga/fga_provider_db.py
+++ b/src/register_your_data_api/auth/fga/fga_provider_db.py
@@ -63,6 +63,17 @@ class FineGrainedAuthorisationProviderDb(FineGrainedAuthorisationProvider):
 
         return FineGrainedAuthorisationRoleAssociation(**user_role_for_org.model_dump())
 
+    def get_admin_users_for_org(self, org: UUID) -> list[FineGrainedAuthorisationRoleAssociation]:
+        with Session(self._engine) as session:
+            admin_user_db_fgas = session.exec(
+                select(FineGrainedAuthorisationDbModel).where(
+                    (FineGrainedAuthorisationDbModel.reporting_org == org)
+                    & (FineGrainedAuthorisationDbModel.role == FineGrainedAuthorisationRole.ADMIN)
+                )
+            ).all()
+
+        return [FineGrainedAuthorisationRoleAssociation(**db_fga.model_dump()) for db_fga in admin_user_db_fgas]
+
     def is_user_a_superadmin(self, user: UUID) -> bool:
         with Session(self._engine) as session:
             user_superadmin_record = session.exec(

--- a/src/register_your_data_api/auth/fga/fga_validator.py
+++ b/src/register_your_data_api/auth/fga/fga_validator.py
@@ -40,7 +40,7 @@ class FineGrainedAuthorisationUserValidator(pydantic.BaseModel):
             id_as_uuid = reporting_org_id if isinstance(reporting_org_id, UUID) else UUID(reporting_org_id)
             reporting_orgs = list(filter(lambda x: x.reporting_org == id_as_uuid, self.fine_grained_authorisations))
 
-        if len(reporting_orgs) == 1:
+        if len(reporting_orgs) >= 1:
             return reporting_orgs[0].role
 
         if self.is_superadmin:

--- a/src/register_your_data_api/background_tasks.py
+++ b/src/register_your_data_api/background_tasks.py
@@ -1,0 +1,82 @@
+import functools
+import inspect
+import logging
+from enum import Enum, auto
+from typing import Any, Awaitable, Callable, ParamSpec, TypeVar, cast
+
+from email_validator import EmailNotValidError, validate_email
+from fastapi import BackgroundTasks
+
+from register_your_data_api.email_generator import Email
+from register_your_data_api.email_sender import EmailSender
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+class ActionType(Enum):
+    SEND_EMAIL = auto()
+
+
+app_logger: logging.Logger = logging.getLogger("ryd-api")
+audit_logger: logging.Logger = logging.getLogger("ryd-api-audit")
+
+
+def background_task_handler(func: Callable[P, R] | Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
+    """Decorator that wraps background tasks with error handling and logging."""
+
+    @functools.wraps(func)
+    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:  # type: ignore
+        try:
+            app_logger.info(f"Starting task: {func.__name__}")
+            result = func(*args, **kwargs)
+            if inspect.isawaitable(result):
+                return await cast(Awaitable[R], result)
+            return result
+        except Exception as e:
+            app_logger.error(f"Failed task {func.__name__}: {e}", exc_info=True)
+
+    return wrapper
+
+
+def enqueue_task(background_tasks: BackgroundTasks, action: ActionType, *args: Any, **kwargs: Any) -> None:
+    """Add a task to the background task processor"""
+
+    if action == ActionType.SEND_EMAIL:
+        background_tasks.add_task(send_email_async, *args, **kwargs)
+    else:
+        raise ValueError(f"Error: request to add an unknown action type to the background task queue: {action}")
+
+
+@background_task_handler  # type: ignore
+async def send_email_async(email_sender: EmailSender, trace_id: str, email: Email) -> None:
+    """Sends an email to the Azure Communication Services for sending asynchronously"""
+
+    try:
+        validate_email(email.to_email, check_deliverability=False)
+    except EmailNotValidError:
+        app_logger.info(
+            f"send_email_async() - Email address is invalid - trace id: {trace_id} - subject: {email.subject}"
+        )
+        audit_logger.info(
+            f"send_email_async() - Email address is invalid - trace id: {trace_id} - "
+            f"recipient: {email.to_email} - subject: {email.subject}"
+        )
+        return
+
+    app_logger.debug(f"Sending email to: {email.to_email}")
+    app_logger.debug(
+        "Email content - subject=%s from_name=%s from_email=%s to_name=%s to_email=%s",
+        email.subject,
+        email.from_name,
+        email.from_email,
+        email.to_name,
+        email.to_email,
+    )
+
+    email_sender.send(email)
+
+    audit_logger.info(
+        f"send_email_async() - Sending email to Azure comms service - trace id: {trace_id} - "
+        f"recipient: {email.to_email} - subject: {email.subject}"
+    )

--- a/src/register_your_data_api/background_tasks.py
+++ b/src/register_your_data_api/background_tasks.py
@@ -1,4 +1,5 @@
 import functools
+import hashlib
 import inspect
 import logging
 from enum import Enum, auto
@@ -64,19 +65,21 @@ async def send_email_async(email_sender: EmailSender, trace_id: str, email: Emai
         )
         return
 
-    app_logger.debug(f"Sending email to: {email.to_email}")
-    app_logger.debug(
-        "Email content - subject=%s from_name=%s from_email=%s to_name=%s to_email=%s",
-        email.subject,
-        email.from_name,
-        email.from_email,
-        email.to_name,
-        email.to_email,
-    )
+    recipient_email_hashed = hashlib.sha256(email.to_email.encode()).hexdigest()
 
-    email_sender.send(email)
+    app_logger.debug(
+        f"send_email_async() - Sending email to Azure comms service - trace id: {trace_id} - "
+        f"recipient: {recipient_email_hashed}"
+    )
 
     audit_logger.info(
         f"send_email_async() - Sending email to Azure comms service - trace id: {trace_id} - "
         f"recipient: {email.to_email} - subject: {email.subject}"
     )
+    audit_logger.debug(
+        f"send_email_async() - Sending email to Azure comms service - trace id: {trace_id} - "
+        f"recipient: {email.to_email} - subject: {email.subject}"
+        f"recipient name: {email.to_name}"
+    )
+
+    email_sender.send(email)

--- a/src/register_your_data_api/data_handling/data_schemas.py
+++ b/src/register_your_data_api/data_handling/data_schemas.py
@@ -1,4 +1,5 @@
 import re
+import uuid
 from typing import Annotated, Literal
 
 import pydantic
@@ -18,7 +19,12 @@ class BaseResponse(pydantic.BaseModel):
 
 
 class OrganisationId(pydantic.BaseModel):
-    oid: str
+    oid: uuid.UUID
+
+    @pydantic.computed_field  # type: ignore[prop-decorator]
+    @property
+    def oid_str(self) -> str:
+        return str(self.oid)
 
 
 class CRMUser(pydantic.BaseModel):

--- a/src/register_your_data_api/email_generator.py
+++ b/src/register_your_data_api/email_generator.py
@@ -1,0 +1,101 @@
+"""Email content generation using Jinja2 templates"""
+
+from dataclasses import dataclass
+from enum import Enum
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+
+@dataclass
+class Email:
+    """Container for generated email content"""
+
+    from_name: str
+    from_email: str
+    to_name: str
+    to_email: str
+    subject: str
+    content_text: str
+    content_html: str
+
+
+class EmailType(Enum):
+    """Types of emails that can be generated"""
+
+    USER_REQUESTED_TO_JOIN_ORG = "user_requested_to_join_org"
+    NEW_ORG_NEEDS_APPROVAL = "new_org_needs_approval"
+
+
+class EmailGenerator:
+    """Generates email content from Jinja2 templates"""
+
+    def __init__(self, templates_dir: str) -> None:
+        """
+        Initialize the email generator.
+
+        Args:
+            templates_dir: Path to the directory containing email templates
+        """
+        self._templates_dir = templates_dir
+
+    def _get_jinja_env(self) -> Environment:
+        """Create and return a Jinja2 environment configured for email templates"""
+        return Environment(loader=FileSystemLoader(self._templates_dir), autoescape=select_autoescape(["html"]))
+
+    def generate_email_content(
+        self,
+        email_type: EmailType,
+        from_name: str,
+        from_email: str,
+        to_name: str,
+        to_email: str,
+        **template_vars: str,
+    ) -> Email:
+        """
+        Generate email content using Jinja2 templates.
+
+        Args:
+            email_type: The type of email to generate
+            from_name: The name of the sender
+            from_email: The email address of the sender
+            to_name: The name of the recipient
+            to_email: The email address of the recipient
+            **template_vars: Additional template variables specific to the email type
+
+        Returns:
+            An Email object containing subject, text content, and HTML content
+        """
+        template_base_name = email_type.value
+
+        # Combine standard variables with any additional template-specific variables
+        context = {
+            "from_name": from_name,
+            "from_email": from_email,
+            "to_name": to_name,
+            "to_email": to_email,
+            **template_vars,
+        }
+
+        # Render subject (no autoescape)
+        text_env = self._get_jinja_env()
+        subject_template = text_env.get_template(f"{template_base_name}_subject.txt")
+        subject = subject_template.render(**context).strip()
+
+        # Render text version (no autoescape)
+        text_template = text_env.get_template(f"{template_base_name}.txt")
+        text_content = text_template.render(**context)
+
+        # Render HTML version (with autoescape)
+        html_env = self._get_jinja_env()
+        html_template = html_env.get_template(f"{template_base_name}.html")
+        html_content = html_template.render(**context)
+
+        return Email(
+            from_name=from_name,
+            from_email=from_email,
+            to_name=to_name,
+            to_email=to_email,
+            subject=subject,
+            content_text=text_content,
+            content_html=html_content,
+        )

--- a/src/register_your_data_api/email_sender.py
+++ b/src/register_your_data_api/email_sender.py
@@ -1,0 +1,36 @@
+"""Email sending abstractions and Azure implementation."""
+
+from abc import ABC, abstractmethod
+
+from azure.communication.email import EmailClient
+
+from register_your_data_api.email_generator import Email
+
+
+class EmailSender(ABC):
+    """Abstract email sender for an Email object."""
+
+    @abstractmethod
+    def send(self, email: Email) -> None:
+        """Send the email."""
+        raise NotImplementedError
+
+
+class AzureEmailSender(EmailSender):
+    """Send emails using Azure Communication Services EmailClient."""
+
+    def __init__(self, connection_string: str) -> None:
+        self._client = EmailClient.from_connection_string(connection_string)
+
+    def send(self, email: Email) -> None:
+        message = {
+            "senderAddress": email.from_email,
+            "replyTo": [{"address": email.from_email, "displayName": email.from_name}],
+            "recipients": {"to": [{"address": email.to_email, "displayName": email.to_name}]},
+            "content": {
+                "subject": email.subject,
+                "plainText": email.content_text,
+                "html": email.content_html,
+            },
+        }
+        self._client.begin_send(message)

--- a/src/register_your_data_api/routers/reporting_orgs.py
+++ b/src/register_your_data_api/routers/reporting_orgs.py
@@ -5,12 +5,15 @@ from typing import Any, Callable
 
 import fastapi
 import starlette.requests
-from fastapi import Depends, Security
+from fastapi import BackgroundTasks, Depends, Security
 from fastapi.exceptions import HTTPException
 from fastapi.responses import JSONResponse
 from libsuitecrm import Filter, RequestFailed, SuiteCRM  # type: ignore
 
+from register_your_data_api import email_generator
+from register_your_data_api.background_tasks import ActionType, enqueue_task
 from register_your_data_api.dependencies import get_suitecrm_audit_headers
+from register_your_data_api.exceptions import RYDUserException
 
 from ..auth import authz
 from ..auth import models as auth_models
@@ -187,6 +190,7 @@ def get_reporting_org_detail(
 @router.post("", status_code=201)
 def create_reporting_org(
     request: starlette.requests.Request,
+    background_tasks: BackgroundTasks,
     reporting_org: ReportingOrgUserCreateModel,
     user: auth_models.UserAndCredentials = Security(
         authz.get_user_authnz, scopes=["ryd", "ryd:reporting_org", "ryd:reporting_org:create"]
@@ -195,6 +199,8 @@ def create_reporting_org(
 ) -> UserReportingOrgRelationSingleResponse:
 
     context: Context = request.app.state.context
+
+    trace_id: uuid.UUID = uuid.uuid4()
 
     assert_precondition_met(
         context,
@@ -246,10 +252,11 @@ def create_reporting_org(
             )
         )
 
-        # 2. Create a relationship between the current user (Contacts) and the
-        # reporting org (Accounts) in SuiteCRM, but only if user is not
-        # operating in the capacity as a super_admin
+        # If user not superadmin, create relationship in CRM and entry in FGA db
         if not user.validator.is_superadmin:
+            # 2. Create a relationship between the current user (Contacts) and the
+            # reporting org (Accounts) in SuiteCRM, but only if user is not
+            # operating in the capacity as a super_admin
             crm.create_relationship(
                 "Accounts",
                 suitecrm_reporting_org["id"],
@@ -267,20 +274,45 @@ def create_reporting_org(
             )
             undo_actions.append((undo_msg, undo_func))
 
-        # 3. Create a fine-grained authorisation for this user to be ADMIN of new reporting_org
-        user_reporting_org_role = fga_models.FineGrainedAuthorisationRoleAssociation(
-            user=uuid.UUID(user.user_id_crm),
-            reporting_org=uuid.UUID(suitecrm_reporting_org["id"]),
-            role=fga_models.FineGrainedAuthorisationRole.ADMIN,
-        )
-        context.fine_grained_auth_provider.create_user_fine_grained_authorisation(user_reporting_org_role)
+            # 3. Create a fine-grained authorisation for this user to be ADMIN of new reporting_org
+            user_reporting_org_role = fga_models.FineGrainedAuthorisationRoleAssociation(
+                user=uuid.UUID(user.user_id_crm),
+                reporting_org=uuid.UUID(suitecrm_reporting_org["id"]),
+                role=fga_models.FineGrainedAuthorisationRole.ADMIN,
+            )
+            context.fine_grained_auth_provider.create_user_fine_grained_authorisation(user_reporting_org_role)
+
+        # 4. Fetch the user's name and email from SuiteCRM for email notification
+        filters = Filter().equal("id", user.user_id_crm)
+        crm_user = crm.get_records("Contacts", fields=["last_name", "email1"], filters=filters)
+        if "data" in crm_user and len(crm_user["data"]) > 0:
+            user_name = crm_user["data"][0]["attributes"]["last_name"]
+            user_email = crm_user["data"][0]["attributes"]["email1"]
+        else:
+            raise RYDUserException(
+                user=user,
+                status_code=400,
+                app_msg=(
+                    f"trace id: {trace_id} - User account details for user id: {user.user_id_crm} "
+                    "were not found in SuiteCRM."
+                ),
+                audit_msg=None,
+                public_msg=(
+                    "Problem creating the reporting org: full user account details were not found. "
+                    f"Please contact IATI Support quotating this error trace id: {trace_id}"
+                ),
+            )
+
+    except RYDUserException as e:
+        perform_undo_actions(context, undo_actions, "create_reporting_org", trace_id=trace_id)
+        raise e
 
     except Exception:
-        error_trace_id: uuid.UUID = perform_undo_actions(context, undo_actions, "create_reporting_org")
+        perform_undo_actions(context, undo_actions, "create_reporting_org", trace_id=trace_id)
 
         raise HTTPException(
             fastapi.status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"There was a problem creating the reporting org. Error id: {error_trace_id}",
+            detail=f"There was a problem creating the reporting org. Error id: {trace_id}",
         )
 
     user_reporting_org = UserReportingOrgRelation(
@@ -292,8 +324,33 @@ def create_reporting_org(
 
     context.audit_logger.info(
         format_log_msg(
-            request, user, f"Created reporting org with id: {suitecrm_reporting_org['id']}", include_client_id=True
+            request,
+            user,
+            f"trace id: {trace_id} - Created reporting org with id: {suitecrm_reporting_org['id']}",
+            include_client_id=True,
         )
+    )
+
+    enqueue_task(
+        background_tasks,
+        ActionType.SEND_EMAIL,
+        email_sender=context.email_sender,
+        trace_id=str(trace_id),
+        email=context.email_generator.generate_email_content(
+            email_generator.EmailType.NEW_ORG_NEEDS_APPROVAL,
+            context.email_sender_ryd_from_name,
+            context.email_sender_ryd_from_email,
+            "IATI Support",
+            context.email_address_for_iati_support_approvals,
+            org_id=user_reporting_org.id,
+            org_short_name=user_reporting_org.metadata.short_name if user_reporting_org.metadata.short_name else "",
+            org_human_readable_name=user_reporting_org.metadata.human_readable_name,
+            user_id=user.user_id_crm,
+            user_name=user_name,
+            user_email=user_email,
+            site_url=context.iati_account_instance_base_url,
+            creation_date=str(new_reporting_org.created_date),
+        ),
     )
 
     return UserReportingOrgRelationSingleResponse(status="success", error=None, data=user_reporting_org)

--- a/src/register_your_data_api/routers/users.py
+++ b/src/register_your_data_api/routers/users.py
@@ -180,7 +180,7 @@ def add_user_to_reporting_org(
                     admin_from_suitecrm["data"][0]["attributes"]["last_name"],
                     admin_from_suitecrm["data"][0]["attributes"]["email1"],
                     org_id=payload.oid_str,
-                    org_name=reporting_org_from_suitecrm["attributes"]["name"],
+                    org_human_readable_name=reporting_org_from_suitecrm["attributes"]["name"],
                     user_requesting_join_email=user_requesting_to_join["attributes"]["email1"],
                     user_requesting_join_id=user.user_id_crm,
                     user_requesting_join_name=user_requesting_to_join["attributes"]["last_name"],

--- a/src/register_your_data_api/routers/users.py
+++ b/src/register_your_data_api/routers/users.py
@@ -47,30 +47,26 @@ def add_user_to_reporting_org(
 
     assert_precondition_met(
         context,
+        user,
         condition_func=lambda: user_id_to_add_as_str == user.user_id_crm,
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,
-        public_msg=("You cannot request a different user be associated with a reporting organisation."),
-        app_log_msg=(
-            f"Error: - user id: {user.user_id_crm} - POST /{user_id}/reporting-org - Request to associate user "
-            f"{user_id_to_add_as_str} with reporting org id: {payload.oid} by a different user with "
-            f"id: {user.user_id_crm}"
-        ),
+        public_msg=("You cannot request a different user to join a reporting organisation."),
         audit_log_msg=(
-            f"Error: - user id: {user.user_id_crm} - POST /{user_id}/reporting-org - Request to associate user "
-            f"{user_id_to_add_as_str} with reporting org id: {payload.oid} by a different user with "
-            f"id: {user.user_id_crm}"
+            f"Request to join user id: {user_id_to_add_as_str} to reporting org id: {payload.oid} "
+            f"by a different user."
         ),
     )
 
-    # Superadmins shouldn't be allowed to request association with any organisations
+    # Superadmins shouldn't be allowed to join any organisations
     assert_precondition_met(
         context,
+        user,
         condition_func=lambda: not user.validator.is_superadmin,
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,
-        public_msg=("Superadmins cannot associate themselves with organisations."),
+        public_msg=("Superadmins cannot join organisations."),
         audit_log_msg=(
-            f"Error: - user id: {user.user_id_crm} - POST /{user_id}/reporting-org - Request by a superadmin to "
-            f"associate their account with a reporting org"
+            f"Request by superadmin to join reporting org id: {payload.oid} "
+            "but superadmins cannot join organisations."
         ),
     )
 
@@ -80,24 +76,25 @@ def add_user_to_reporting_org(
     # Check the reporting org exists
     assert_precondition_met(
         context,
+        user,
         condition_func=lambda: check_crm_record_exists(crm, "Accounts", payload.oid),
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,
         public_msg=(f"There is no organisation with ID {payload.oid} in the Registry."),
-        app_log_msg=(
-            f"Error: - user id: {user.user_id_crm} - POST /{user_id}/reporting-org - Request by a user to "
-            f"associate their account with a non-existing reporting org"
+        audit_log_msg=(
+            f"Request by user to join a non-existing reporting org with id: {payload.oid}."
         ),
     )
 
     # Check the user isn't already a member of that organisation
     assert_precondition_met(
         context,
+        user,
         condition_func=lambda: user.validator.get_user_role_for_reporting_org(payload.oid) is None,
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,
         public_msg=(f"You are already associated with that reporting org id: {payload.oid}."),
-        app_log_msg=(
-            f"Error: - user id: {user.user_id_crm} - POST /{user_id}/reporting-org - Request by a user to "
-            f"join reporting org id: {payload.oid}, but they are already a member of that organisation"
+        audit_log_msg=(
+            f"Request by user to join reporting org id: {payload.oid} "
+            "but they are already a member of that organisation."
         ),
     )
 
@@ -172,7 +169,7 @@ def update_user_role_in_reporting_org(
         condition_func=lambda: check_crm_record_exists(crm, "Contacts", str(user_id)),
         public_msg=f"There is no user with ID {str(user_id)} in the Registry.",
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,
-        app_log_msg=(
+        audit_log_msg=(
             f"User with id: {user.user_id_crm} attempted to change user id: {user_id}'s role "
             f"in organisation with id: {org_id} but user with id: {user_id} does not exist in CRM."
         ),
@@ -188,7 +185,7 @@ def update_user_role_in_reporting_org(
         condition_func=lambda: check_crm_record_exists(crm, "Accounts", str(org_id)),
         public_msg=f"There is no organisation with ID {str(org_id)} in the Registry.",
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,
-        app_log_msg=(
+        audit_log_msg=(
             f"User with id: {user.user_id_crm} attempted to change user id: {user_id}'s role "
             f"in organisation with id: {org_id} but organisation with id {org_id} does not exist in CRM."
         ),
@@ -203,7 +200,7 @@ def update_user_role_in_reporting_org(
         condition_func=lambda: not context.fine_grained_auth_provider.is_user_a_superadmin(user_id),
         public_msg=f"User id: {user_id} cannot be given a role in no organisation with ID {str(org_id)}.",
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,
-        app_log_msg=(
+        audit_log_msg=(
             f"User with id: {user.user_id_crm} attempted to change user id: {user_id}'s role "
             f"in organisation with id: {org_id} but user with id: {user_id} is a superadmin."
         ),
@@ -310,7 +307,7 @@ def remove_user_from_reporting_org(
         condition_func=lambda: check_crm_record_exists(crm, "Contacts", str(user_id)),
         public_msg=f"There is no user with ID {str(user_id)} in the Registry.",
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,
-        app_log_msg=(
+        audit_log_msg=(
             f"User with id: {user.user_id_crm} attempted to remove user id: {user_id}'s role "
             f"in organisation with id: {org_id} but user with id: {user_id} does not exist in CRM."
         ),
@@ -323,7 +320,7 @@ def remove_user_from_reporting_org(
         condition_func=lambda: check_crm_record_exists(crm, "Accounts", str(org_id)),
         public_msg=f"There is no organisation with ID {str(org_id)} in the Registry.",
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,
-        app_log_msg=(
+        audit_log_msg=(
             f"User with id: {user.user_id_crm} attempted to change user id: {user_id}'s role "
             f"in organisation with id: {org_id} but organisation with id {org_id} does not exist in CRM."
         ),

--- a/src/register_your_data_api/routers/users.py
+++ b/src/register_your_data_api/routers/users.py
@@ -89,6 +89,18 @@ def add_user_to_reporting_org(
         ),
     )
 
+    # Check the user isn't already a member of that organisation
+    assert_precondition_met(
+        context,
+        condition_func=lambda: user.validator.get_user_role_for_reporting_org(payload.oid) is None,
+        status_code=fastapi.status.HTTP_400_BAD_REQUEST,
+        public_msg=(f"You are already associated with that reporting org id: {payload.oid}."),
+        app_log_msg=(
+            f"Error: - user id: {user.user_id_crm} - POST /{user_id}/reporting-org - Request by a user to "
+            f"join reporting org id: {payload.oid}, but they are already a member of that organisation"
+        ),
+    )
+
     undo_actions: list[tuple[str, Callable[[], Any]]] = []
 
     try:

--- a/src/register_your_data_api/routers/users.py
+++ b/src/register_your_data_api/routers/users.py
@@ -5,11 +5,13 @@ from typing import Any, Callable
 
 import fastapi
 import starlette.requests
-from fastapi import Depends, Security
+from fastapi import BackgroundTasks, Depends, Security
 from fastapi.exceptions import HTTPException
 from fastapi.responses import JSONResponse
-from libsuitecrm import SuiteCRM  # type: ignore
+from libsuitecrm import Filter, SuiteCRM  # type: ignore
 
+from register_your_data_api import email_generator
+from register_your_data_api.background_tasks import ActionType, enqueue_task
 from register_your_data_api.dependencies import get_suitecrm_audit_headers
 
 from ..auth import authz
@@ -20,6 +22,7 @@ from ..data_handling.data_schemas import (
     OrganisationId,
     UserRoleUpdateModel,
 )
+from ..exception_handlers import format_log_msg
 from ..util import Context
 from ..utilities import (
     assert_precondition_met,
@@ -36,12 +39,15 @@ def add_user_to_reporting_org(
     user_id: uuid.UUID,
     payload: OrganisationId,
     request: starlette.requests.Request,
+    background_tasks: BackgroundTasks,
     user: UserAndCredentials = Security(authz.get_user_authnz, scopes=["ryd", "ryd:reporting_org:user"]),
     suitecrm_audit_headers: dict[str, str] = Depends(get_suitecrm_audit_headers),
 ) -> JSONResponse:
     """Handles a request by the logged in user to be associated with the specified reporting_org"""
 
     context: Context = request.app.state.context
+
+    trace_id: uuid.UUID = uuid.uuid4()
 
     user_id_to_add_as_str = str(user_id)
 
@@ -52,7 +58,7 @@ def add_user_to_reporting_org(
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,
         public_msg=("You cannot request a different user to join a reporting organisation."),
         audit_log_msg=(
-            f"Request to join user id: {user_id_to_add_as_str} to reporting org id: {payload.oid} "
+            f"Request to join user id: {user_id_to_add_as_str} to reporting org id: {payload.oid_str} "
             f"by a different user."
         ),
     )
@@ -65,7 +71,7 @@ def add_user_to_reporting_org(
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,
         public_msg=("Superadmins cannot join organisations."),
         audit_log_msg=(
-            f"Request by superadmin to join reporting org id: {payload.oid} "
+            f"Request by superadmin to join reporting org id: {payload.oid_str} "
             "but superadmins cannot join organisations."
         ),
     )
@@ -73,17 +79,19 @@ def add_user_to_reporting_org(
     # Query SuiteCRM to check that the reporting_org exists
     crm: SuiteCRM = context.suitecrm_client_factory.get_client()
 
+    org_response = crm.get_records("Accounts", filters=Filter().equal("id", payload.oid_str), fields=["id", "name"])
+
     # Check the reporting org exists
     assert_precondition_met(
         context,
         user,
-        condition_func=lambda: check_crm_record_exists(crm, "Accounts", payload.oid),
+        condition_func=lambda: len(org_response["data"]) == 1,
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,
-        public_msg=(f"There is no organisation with ID {payload.oid} in the Registry."),
-        audit_log_msg=(
-            f"Request by user to join a non-existing reporting org with id: {payload.oid}."
-        ),
+        public_msg=(f"There is no organisation with ID {payload.oid_str} in the Registry."),
+        audit_log_msg=(f"Request by user to join a non-existing reporting org with id: {payload.oid_str}."),
     )
+
+    reporting_org_from_suitecrm = org_response["data"][0]
 
     # Check the user isn't already a member of that organisation
     assert_precondition_met(
@@ -91,41 +99,124 @@ def add_user_to_reporting_org(
         user,
         condition_func=lambda: user.validator.get_user_role_for_reporting_org(payload.oid) is None,
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,
-        public_msg=(f"You are already associated with that reporting org id: {payload.oid}."),
+        public_msg=(f"You are already associated with that reporting org id: {payload.oid_str}."),
         audit_log_msg=(
-            f"Request by user to join reporting org id: {payload.oid} "
+            f"Request by user to join reporting org id: {payload.oid_str} "
             "but they are already a member of that organisation."
         ),
     )
+
+    user_response = crm.get_records(
+        "Contacts", filters=Filter().equal("id", user.user_id_crm), fields=["id", "email1", "last_name"]
+    )
+
+    user_requesting_to_join = user_response["data"][0]
 
     undo_actions: list[tuple[str, Callable[[], Any]]] = []
 
     try:
         # 1. Create a relationship between the current user (Contacts) and the
         crm.create_relationship(
-            "Accounts", payload.oid, "contacts", "Contacts", user.user_id_crm, headers=suitecrm_audit_headers
+            "Accounts", payload.oid_str, "contacts", "Contacts", user.user_id_crm, headers=suitecrm_audit_headers
         )
-        undo_msg = f"delete relationship between organisation id: {payload.oid} and user id: {user.user_id_crm}"
+        undo_msg = f"delete relationship between organisation id: {payload.oid_str} and user id: {user.user_id_crm}"
         undo_func: Callable[[], Any] = lambda: crm.delete_relationship(
-            "Accounts", payload.oid, "contacts", user.user_id_crm, headers=suitecrm_audit_headers
+            "Accounts", payload.oid_str, "contacts", user.user_id_crm, headers=suitecrm_audit_headers
         )
         undo_actions.append((undo_msg, undo_func))
+
+        context.audit_logger.info(
+            format_log_msg(
+                request,
+                user,
+                (
+                    f"trace id: {trace_id} - request to join organisation id: "
+                    f"{payload.oid_str} - crm relationship created."
+                ),
+                include_client_id=True,
+            )
+        )
 
         # 2. Create a fine-grained authorisation for this user to be CONTRIBUTOR_PENDING of new reporting_org
         user_reporting_org_role = fga_models.FineGrainedAuthorisationRoleAssociation(
             user=uuid.UUID(user.user_id_crm),
-            reporting_org=uuid.UUID(payload.oid),
+            reporting_org=payload.oid,
             role=fga_models.FineGrainedAuthorisationRole.CONTRIBUTOR_PENDING,
         )
         context.fine_grained_auth_provider.create_user_fine_grained_authorisation(user_reporting_org_role)
 
+        context.audit_logger.info(
+            format_log_msg(
+                request,
+                user,
+                (
+                    f"trace id: {trace_id} - request to join organisation id: "
+                    f"{payload.oid_str} - entry in FGA DB created."
+                ),
+                include_client_id=True,
+            )
+        )
+
+        # 3. Add a send-email task to the background task processor for each organisation admin
+        # - lookup the organisation admins
+        # - read the admins names and email addresses from SuiteCRM
+        # - enqueue the email send task for each admin
+        org_admins = context.fine_grained_auth_provider.get_admin_users_for_org(payload.oid)
+
+        for org_admin in org_admins:
+            admin_from_suitecrm = crm.get_records(
+                "Contacts", filters=Filter().equal("id", str(org_admin.user)), fields=["id", "email1", "last_name"]
+            )
+
+            enqueue_task(
+                background_tasks,
+                ActionType.SEND_EMAIL,
+                email_sender=context.email_sender,
+                trace_id=str(trace_id),
+                email=context.email_generator.generate_email_content(
+                    email_generator.EmailType.USER_REQUESTED_TO_JOIN_ORG,
+                    context.email_sender_ryd_from_name,
+                    context.email_sender_ryd_from_email,
+                    admin_from_suitecrm["data"][0]["attributes"]["last_name"],
+                    admin_from_suitecrm["data"][0]["attributes"]["email1"],
+                    org_id=payload.oid_str,
+                    org_name=reporting_org_from_suitecrm["attributes"]["name"],
+                    user_requesting_join_email=user_requesting_to_join["attributes"]["email1"],
+                    user_requesting_join_id=user.user_id_crm,
+                    user_requesting_join_name=user_requesting_to_join["attributes"]["last_name"],
+                    site_url=context.iati_account_instance_base_url,
+                ),
+            )
+
+        if len(org_admins) == 0:
+            context.app_logger.error(
+                format_log_msg(
+                    request,
+                    user,
+                    (
+                        f"trace id: {trace_id} - User requested to join organisation id: {payload.oid_str} and "
+                        "their request has been processed but no admins were found for this organisation so no email "
+                        "notifications were sent."
+                    ),
+                )
+            )
+
     except Exception:
-        error_trace_id: uuid.UUID = perform_undo_actions(context, undo_actions, "add_user_to_reporting_org")
+        perform_undo_actions(context, undo_actions, "add_user_to_reporting_org", trace_id=trace_id)
 
         raise HTTPException(
             fastapi.status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"There was a problem requesting access to the organisation. Error id: {error_trace_id}",
+            detail=f"There was a problem requesting access to the organisation. Error id: {trace_id}",
         )
+
+    context.audit_logger.info(
+        format_log_msg(
+            request,
+            user,
+            (f"trace id: {trace_id} - request to join organisation id: {payload.oid_str} succeeded."),
+            include_client_id=True,
+        )
+    )
 
     return JSONResponse({"data": None, "error": None, "status": "success"}, 200)
 

--- a/src/register_your_data_api/routers/users.py
+++ b/src/register_your_data_api/routers/users.py
@@ -45,31 +45,49 @@ def add_user_to_reporting_org(
 
     user_id_to_add_as_str = str(user_id)
 
-    if user_id_to_add_as_str != user.user_id_crm:
-        context.audit_logger.error(
-            f"Request to associate user with id: {user_id_to_add_as_str} to organisation with id: {payload.oid} "
-            f"by user with non-matching id: {user.user_id_crm}"
-        )
-        raise HTTPException(
-            status_code=fastapi.status.HTTP_400_BAD_REQUEST,
-            detail="You cannot request a different user be associated with a reporting organisation.",
-        )
+    assert_precondition_met(
+        context,
+        condition_func=lambda: user_id_to_add_as_str == user.user_id_crm,
+        status_code=fastapi.status.HTTP_400_BAD_REQUEST,
+        public_msg=("You cannot request a different user be associated with a reporting organisation."),
+        app_log_msg=(
+            f"Error: - user id: {user.user_id_crm} - POST /{user_id}/reporting-org - Request to associate user "
+            f"{user_id_to_add_as_str} with reporting org id: {payload.oid} by a different user with "
+            f"id: {user.user_id_crm}"
+        ),
+        audit_log_msg=(
+            f"Error: - user id: {user.user_id_crm} - POST /{user_id}/reporting-org - Request to associate user "
+            f"{user_id_to_add_as_str} with reporting org id: {payload.oid} by a different user with "
+            f"id: {user.user_id_crm}"
+        ),
+    )
 
     # Superadmins shouldn't be allowed to request association with any organisations
-    if user.validator.is_superadmin:
-        raise HTTPException(
-            status_code=fastapi.status.HTTP_400_BAD_REQUEST,
-            detail="Superadmins cannot associate themselves with organisations.",
-        )
+    assert_precondition_met(
+        context,
+        condition_func=lambda: not user.validator.is_superadmin,
+        status_code=fastapi.status.HTTP_400_BAD_REQUEST,
+        public_msg=("Superadmins cannot associate themselves with organisations."),
+        audit_log_msg=(
+            f"Error: - user id: {user.user_id_crm} - POST /{user_id}/reporting-org - Request by a superadmin to "
+            f"associate their account with a reporting org"
+        ),
+    )
 
     # Query SuiteCRM to check that the reporting_org exists
     crm: SuiteCRM = context.suitecrm_client_factory.get_client()
 
-    if not check_crm_record_exists(crm, "Accounts", payload.oid):
-        raise HTTPException(
-            status_code=fastapi.status.HTTP_400_BAD_REQUEST,
-            detail=f"There is no organisation with ID {payload.oid} in the Registry.",
-        )
+    # Check the reporting org exists
+    assert_precondition_met(
+        context,
+        condition_func=lambda: check_crm_record_exists(crm, "Accounts", payload.oid),
+        status_code=fastapi.status.HTTP_400_BAD_REQUEST,
+        public_msg=(f"There is no organisation with ID {payload.oid} in the Registry."),
+        app_log_msg=(
+            f"Error: - user id: {user.user_id_crm} - POST /{user_id}/reporting-org - Request by a user to "
+            f"associate their account with a non-existing reporting org"
+        ),
+    )
 
     undo_actions: list[tuple[str, Callable[[], Any]]] = []
 
@@ -84,7 +102,7 @@ def add_user_to_reporting_org(
         )
         undo_actions.append((undo_msg, undo_func))
 
-        # 2. Create a fine-grained authorisation for this user to be CONTRIBUTOR of new reporting_org
+        # 2. Create a fine-grained authorisation for this user to be CONTRIBUTOR_PENDING of new reporting_org
         user_reporting_org_role = fga_models.FineGrainedAuthorisationRoleAssociation(
             user=uuid.UUID(user.user_id_crm),
             reporting_org=uuid.UUID(payload.oid),

--- a/src/register_your_data_api/util.py
+++ b/src/register_your_data_api/util.py
@@ -15,6 +15,8 @@ from register_your_data_api.client_application_details_provider import (
     ClientApplicationDetails,
     ClientApplicationDetailsProvider,
 )
+from register_your_data_api.email_generator import EmailGenerator
+from register_your_data_api.email_sender import AzureEmailSender, EmailSender
 from register_your_data_api.suitecrm_client_factory import SuiteCRMClientFactory
 
 from .audit import EncryptedFormatter
@@ -31,16 +33,22 @@ class Context:
         "APP_LOG_PATH",
         "AUDIT_LOG_PATH",
         "AUDIT_LOG_PUBLIC_KEY_PATH",
-        "JWKS_URI",
-        "PROMETHEUS_PORT",
-        "JWT_AUDIENCE",
-        "FGA_PROVIDER",
-        "FGA_PROVIDER_CONNECTION_STRING",
+        "AZURE_COMMUNICATION_SERVICE_CONNECTION_STRING",
+        "CLIENT_APPLICATION_DETAILS_FILE",
         "DATA_REGISTRY_SUITECRM_API_URL",
         "DATA_REGISTRY_SUITECRM_CLIENT_ID",
         "DATA_REGISTRY_SUITECRM_CLIENT_SECRET",
+        "EMAIL_ADDRESS_FOR_IATI_SUPPORT_APPROVALS",
+        "EMAIL_SENDER_RYD_FROM_NAME",
+        "EMAIL_SENDER_RYD_FROM_EMAIL",
+        "EMAIL_TEMPLATES_DIR",
+        "FGA_PROVIDER",
+        "FGA_PROVIDER_CONNECTION_STRING",
+        "IATI_ACCOUNT_INSTANCE_BASE_URL",
+        "JWKS_URI",
+        "JWT_AUDIENCE",
+        "PROMETHEUS_PORT",
         "USER_CRM_UUID_CONFIG_STRING",
-        "CLIENT_APPLICATION_DETAILS_FILE",
     ]
 
     LOG_LEVELS: Final[dict[str, int]] = {
@@ -61,7 +69,16 @@ class Context:
     _audit_log_fh: TextIO
     _audit_log_file_handler: logging.StreamHandler[TextIO]
 
+    _email_address_for_iati_support_approvals: str
+    _email_generator: EmailGenerator
+    _email_sender_ryd_from_name: str
+    _email_sender_ryd_from_email: str
+    _email_sender: EmailSender
+
     _env: dict[str, Any]
+
+    _iati_account_instance_base_url: str
+
     _LICENCES: dict[str, str]
 
     _prom_metrics: dict[str, Counter | Info | Gauge]
@@ -112,6 +129,28 @@ class Context:
             self._setup_client_application_details_provider()
         except Exception as err:
             self._app_logger.fatal(f"Cannot setup client application details provider ({err})")
+            raise err
+
+        self._email_address_for_iati_support_approvals = self._env["EMAIL_ADDRESS_FOR_IATI_SUPPORT_APPROVALS"]
+
+        self._email_sender_ryd_from_email = self._env["EMAIL_SENDER_RYD_FROM_EMAIL"]
+
+        self._email_sender_ryd_from_name = self._env["EMAIL_SENDER_RYD_FROM_NAME"]
+
+        self._iati_account_instance_base_url = self._env["IATI_ACCOUNT_INSTANCE_BASE_URL"]
+
+        try:
+            self._app_logger.info("Setting up email generator")
+            self._email_generator = EmailGenerator(self._env["EMAIL_TEMPLATES_DIR"])
+        except Exception as err:
+            self._app_logger.fatal(f"Cannot setup email generator ({err})")
+            raise err
+
+        try:
+            self._app_logger.info("Setting up an Azure Communications Service email sender")
+            self._email_sender = AzureEmailSender(self._env["AZURE_COMMUNICATION_SERVICE_CONNECTION_STRING"])
+        except Exception as err:
+            self._app_logger.fatal(f"Cannot setup email sender ({err})")
             raise err
 
         try:
@@ -305,6 +344,56 @@ class Context:
         return self._audit_logger
 
     @property
+    def email_address_for_iati_support_approvals(self) -> str:
+        """Get method for the IATI Support email address to which Secretariat approvals will be sent
+
+        Returns
+        -------
+        str
+        """
+        return self._email_address_for_iati_support_approvals
+
+    @property
+    def email_generator(self) -> EmailGenerator:
+        """Get method to retrieve the email generator.
+
+        Returns
+        -------
+        EmailGenerator
+        """
+        return self._email_generator
+
+    @property
+    def email_sender(self) -> EmailSender:
+        """Get method to retrieve the email sender.
+
+        Returns
+        -------
+        EmailSender
+        """
+        return self._email_sender
+
+    @property
+    def email_sender_ryd_from_email(self) -> str:
+        """Get method for the IATI email address from which to send notification emails
+
+        Returns
+        -------
+        str
+        """
+        return self._email_sender_ryd_from_email
+
+    @property
+    def email_sender_ryd_from_name(self) -> str:
+        """Get method for the IATI name from which to send notification emails
+
+        Returns
+        -------
+        str
+        """
+        return self._email_sender_ryd_from_name
+
+    @property
     def env(self) -> dict[str, str]:
         """Get method to retrieve the environment variables.
 
@@ -313,6 +402,16 @@ class Context:
         dict[str, str]
         """
         return self._env
+
+    @property
+    def iati_account_instance_base_url(self) -> str:
+        """Get method for the IATI Account instance base URL
+
+        Returns
+        -------
+        str
+        """
+        return self._iati_account_instance_base_url
 
     @property
     def key_store(self) -> jwt.jwks_client.PyJWKClient:

--- a/src/register_your_data_api/utilities.py
+++ b/src/register_your_data_api/utilities.py
@@ -120,7 +120,10 @@ def get_num_crm_records(crm: SuiteCRM, module: str, field_value_pairs: dict[str,
 
 
 def perform_undo_actions(
-    context: Context, undo_actions: list[tuple[str, Callable[[], Any]]], func_name: str
+    context: Context,
+    undo_actions: list[tuple[str, Callable[[], Any]]],
+    func_name: str,
+    trace_id: uuid.UUID | None = None,
 ) -> uuid.UUID:
     """Runs the set of undo actions
 
@@ -139,7 +142,7 @@ def perform_undo_actions(
         The error trace ID for the logged exception
     """
 
-    error_id = uuid.uuid4()
+    error_id = uuid.uuid4() if trace_id is None else trace_id
 
     context.app_logger.exception(f"Unexpected error in {func_name}. Error trace id: {error_id}")
 

--- a/tests/artefacts/suitecrm-mocked-responses/get_records_contact_a1b191ee-4c12-461c-cbe1-68de8173f628.json
+++ b/tests/artefacts/suitecrm-mocked-responses/get_records_contact_a1b191ee-4c12-461c-cbe1-68de8173f628.json
@@ -1,0 +1,195 @@
+{
+    "data": [
+        {
+            "type": "Contact",
+            "id": "a1b191ee-4c12-461c-cbe1-68de8173f628",
+            "attributes": {
+                "name": "Person Three",
+                "date_entered": "2025-10-02T13:40:00+00:00",
+                "date_modified": "2025-10-13T09:34:00+00:00",
+                "modified_user_id": "1",
+                "modified_by_name": "Administrator",
+                "created_by": "1",
+                "created_by_name": "Administrator",
+                "description": "",
+                "deleted": "0",
+                "created_by_link": "",
+                "modified_user_link": "",
+                "assigned_user_id": "1",
+                "assigned_user_name": "Administrator",
+                "assigned_user_link": "",
+                "SecurityGroups": "",
+                "salutation": "",
+                "first_name": "",
+                "last_name": "Person Three",
+                "full_name": "Person Three",
+                "title": "",
+                "photo": "",
+                "department": "",
+                "do_not_call": "0",
+                "phone_home": "",
+                "email": "",
+                "phone_mobile": "",
+                "phone_work": "",
+                "phone_other": "",
+                "phone_fax": "",
+                "email1": "person.three@example.com",
+                "email2": "",
+                "invalid_email": "",
+                "email_opt_out": "",
+                "lawful_basis": "",
+                "date_reviewed": "",
+                "lawful_basis_source": "",
+                "primary_address_street": "",
+                "primary_address_street_2": "",
+                "primary_address_street_3": "",
+                "primary_address_city": "",
+                "primary_address_state": "",
+                "primary_address_postalcode": "",
+                "primary_address_country": "",
+                "alt_address_street": "",
+                "alt_address_street_2": "",
+                "alt_address_street_3": "",
+                "alt_address_city": "",
+                "alt_address_state": "",
+                "alt_address_postalcode": "",
+                "alt_address_country": "",
+                "assistant": "",
+                "assistant_phone": "",
+                "email_addresses_primary": "",
+                "email_addresses": "",
+                "email_addresses_non_primary": "",
+                "email_and_name1": "",
+                "lead_source": "",
+                "account_name": "Global Agency ABC",
+                "account_id": "552376ae-2aa7-98ab-d800-68daa9bfeb4a",
+                "opportunity_role_fields": "",
+                "opportunity_role_id": "",
+                "opportunity_role": "",
+                "reports_to_id": "",
+                "report_to_name": "",
+                "birthdate": "",
+                "accounts": "",
+                "reports_to_link": {},
+                "opportunities": "",
+                "bugs": "",
+                "calls": "",
+                "cases": "",
+                "direct_reports": "",
+                "emails": "",
+                "documents": "",
+                "leads": "",
+                "meetings": "",
+                "notes": "",
+                "project": "",
+                "project_resource": "",
+                "am_projecttemplates_resources": "",
+                "am_projecttemplates_contacts_1": "",
+                "tasks": "",
+                "tasks_parent": "",
+                "notes_parent": "",
+                "user_sync": {},
+                "campaign_id": "",
+                "campaign_name": "",
+                "campaigns": "",
+                "campaign_contacts": {},
+                "c_accept_status_fields": "",
+                "m_accept_status_fields": "",
+                "accept_status_id": "",
+                "accept_status_name": "",
+                "prospect_lists": "",
+                "sync_contact": "",
+                "fp_events_contacts": "",
+                "aos_quotes": "",
+                "aos_invoices": "",
+                "aos_contracts": "",
+                "e_invite_status_fields": "",
+                "event_status_name": "",
+                "event_invite_id": "",
+                "e_accept_status_fields": "",
+                "event_accept_status": "",
+                "event_status_id": "",
+                "project_contacts_1": "",
+                "aop_case_updates": "",
+                "joomla_account_id": "",
+                "portal_account_disabled": "0",
+                "joomla_account_access": "",
+                "portal_user_type": "Single",
+                "iati_country": "GB",
+                "iati_inperson_name": "",
+                "iati_online_name": "",
+                "iati_identityservice_id": "",
+                "iati_mailing_list_subscriber": "0",
+                "iati_timezone": "GMT",
+                "iati_preferred_languages": "",
+                "contact_iati_datasets": "",
+                "jjwg_maps_lng_c": "0.00000000",
+                "jjwg_maps_lat_c": "0.00000000",
+                "jjwg_maps_geocode_status_c": "",
+                "jjwg_maps_address_c": ""
+            },
+            "relationships": {
+                "AM_ProjectTemplates": {
+                    "links": {
+                        "related": "V8/module/Contacts/a1b191ee-4c12-461c-cbe1-68de8173f628/relationships/am_projecttemplates_contacts_1"
+                    }
+                },
+                "AOS_Contracts": {
+                    "links": {
+                        "related": "V8/module/Contacts/a1b191ee-4c12-461c-cbe1-68de8173f628/relationships/aos_contracts"
+                    }
+                },
+                "AOS_Invoices": {
+                    "links": {
+                        "related": "V8/module/Contacts/a1b191ee-4c12-461c-cbe1-68de8173f628/relationships/aos_invoices"
+                    }
+                },
+                "AOS_Quotes": {
+                    "links": {
+                        "related": "V8/module/Contacts/a1b191ee-4c12-461c-cbe1-68de8173f628/relationships/aos_quotes"
+                    }
+                },
+                "CampaignLog": {
+                    "links": {
+                        "related": "V8/module/Contacts/a1b191ee-4c12-461c-cbe1-68de8173f628/relationships/campaigns"
+                    }
+                },
+                "EmailAddress": {
+                    "links": {
+                        "related": "V8/module/Contacts/a1b191ee-4c12-461c-cbe1-68de8173f628/relationships/email_addresses"
+                    }
+                },
+                "IATI_Datasets": {
+                    "links": {
+                        "related": "V8/module/Contacts/a1b191ee-4c12-461c-cbe1-68de8173f628/relationships/contact_iati_datasets"
+                    }
+                },
+                "Opportunities": {
+                    "links": {
+                        "related": "V8/module/Contacts/a1b191ee-4c12-461c-cbe1-68de8173f628/relationships/opportunities"
+                    }
+                },
+                "Project": {
+                    "links": {
+                        "related": "V8/module/Contacts/a1b191ee-4c12-461c-cbe1-68de8173f628/relationships/project_contacts_1"
+                    }
+                },
+                "ProspectLists": {
+                    "links": {
+                        "related": "V8/module/Contacts/a1b191ee-4c12-461c-cbe1-68de8173f628/relationships/prospect_lists"
+                    }
+                },
+                "SecurityGroups": {
+                    "links": {
+                        "related": "V8/module/Contacts/a1b191ee-4c12-461c-cbe1-68de8173f628/relationships/SecurityGroups"
+                    }
+                },
+                "Users": {
+                    "links": {
+                        "related": "V8/module/Contacts/a1b191ee-4c12-461c-cbe1-68de8173f628/relationships/created_by_link"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tests/artefacts/suitecrm-mocked-responses/get_records_contact_bea511d3-c7a7-4097-55ed-68de81e94921.json
+++ b/tests/artefacts/suitecrm-mocked-responses/get_records_contact_bea511d3-c7a7-4097-55ed-68de81e94921.json
@@ -1,0 +1,195 @@
+{
+    "data": [
+        {
+            "type": "Contact",
+            "id": "bea511d3-c7a7-4097-55ed-68de81e94921",
+            "attributes": {
+                "name": "Person Two",
+                "date_entered": "2025-10-02T13:40:00+00:00",
+                "date_modified": "2025-10-13T09:34:00+00:00",
+                "modified_user_id": "1",
+                "modified_by_name": "Administrator",
+                "created_by": "1",
+                "created_by_name": "Administrator",
+                "description": "",
+                "deleted": "0",
+                "created_by_link": "",
+                "modified_user_link": "",
+                "assigned_user_id": "1",
+                "assigned_user_name": "Administrator",
+                "assigned_user_link": "",
+                "SecurityGroups": "",
+                "salutation": "",
+                "first_name": "",
+                "last_name": "Person Two",
+                "full_name": "Person Two",
+                "title": "",
+                "photo": "",
+                "department": "",
+                "do_not_call": "0",
+                "phone_home": "",
+                "email": "",
+                "phone_mobile": "",
+                "phone_work": "",
+                "phone_other": "",
+                "phone_fax": "",
+                "email1": "person.two@example.com",
+                "email2": "",
+                "invalid_email": "",
+                "email_opt_out": "",
+                "lawful_basis": "",
+                "date_reviewed": "",
+                "lawful_basis_source": "",
+                "primary_address_street": "",
+                "primary_address_street_2": "",
+                "primary_address_street_3": "",
+                "primary_address_city": "",
+                "primary_address_state": "",
+                "primary_address_postalcode": "",
+                "primary_address_country": "",
+                "alt_address_street": "",
+                "alt_address_street_2": "",
+                "alt_address_street_3": "",
+                "alt_address_city": "",
+                "alt_address_state": "",
+                "alt_address_postalcode": "",
+                "alt_address_country": "",
+                "assistant": "",
+                "assistant_phone": "",
+                "email_addresses_primary": "",
+                "email_addresses": "",
+                "email_addresses_non_primary": "",
+                "email_and_name1": "",
+                "lead_source": "",
+                "account_name": "Global Agency ABC",
+                "account_id": "552376ae-2aa7-98ab-d800-68daa9bfeb4a",
+                "opportunity_role_fields": "",
+                "opportunity_role_id": "",
+                "opportunity_role": "",
+                "reports_to_id": "",
+                "report_to_name": "",
+                "birthdate": "",
+                "accounts": "",
+                "reports_to_link": {},
+                "opportunities": "",
+                "bugs": "",
+                "calls": "",
+                "cases": "",
+                "direct_reports": "",
+                "emails": "",
+                "documents": "",
+                "leads": "",
+                "meetings": "",
+                "notes": "",
+                "project": "",
+                "project_resource": "",
+                "am_projecttemplates_resources": "",
+                "am_projecttemplates_contacts_1": "",
+                "tasks": "",
+                "tasks_parent": "",
+                "notes_parent": "",
+                "user_sync": {},
+                "campaign_id": "",
+                "campaign_name": "",
+                "campaigns": "",
+                "campaign_contacts": {},
+                "c_accept_status_fields": "",
+                "m_accept_status_fields": "",
+                "accept_status_id": "",
+                "accept_status_name": "",
+                "prospect_lists": "",
+                "sync_contact": "",
+                "fp_events_contacts": "",
+                "aos_quotes": "",
+                "aos_invoices": "",
+                "aos_contracts": "",
+                "e_invite_status_fields": "",
+                "event_status_name": "",
+                "event_invite_id": "",
+                "e_accept_status_fields": "",
+                "event_accept_status": "",
+                "event_status_id": "",
+                "project_contacts_1": "",
+                "aop_case_updates": "",
+                "joomla_account_id": "",
+                "portal_account_disabled": "0",
+                "joomla_account_access": "",
+                "portal_user_type": "Single",
+                "iati_country": "GB",
+                "iati_inperson_name": "",
+                "iati_online_name": "",
+                "iati_identityservice_id": "",
+                "iati_mailing_list_subscriber": "0",
+                "iati_timezone": "GMT",
+                "iati_preferred_languages": "",
+                "contact_iati_datasets": "",
+                "jjwg_maps_lng_c": "0.00000000",
+                "jjwg_maps_lat_c": "0.00000000",
+                "jjwg_maps_geocode_status_c": "",
+                "jjwg_maps_address_c": ""
+            },
+            "relationships": {
+                "AM_ProjectTemplates": {
+                    "links": {
+                        "related": "V8/module/Contacts/bea511d3-c7a7-4097-55ed-68de81e94921/relationships/am_projecttemplates_contacts_1"
+                    }
+                },
+                "AOS_Contracts": {
+                    "links": {
+                        "related": "V8/module/Contacts/bea511d3-c7a7-4097-55ed-68de81e94921/relationships/aos_contracts"
+                    }
+                },
+                "AOS_Invoices": {
+                    "links": {
+                        "related": "V8/module/Contacts/bea511d3-c7a7-4097-55ed-68de81e94921/relationships/aos_invoices"
+                    }
+                },
+                "AOS_Quotes": {
+                    "links": {
+                        "related": "V8/module/Contacts/bea511d3-c7a7-4097-55ed-68de81e94921/relationships/aos_quotes"
+                    }
+                },
+                "CampaignLog": {
+                    "links": {
+                        "related": "V8/module/Contacts/bea511d3-c7a7-4097-55ed-68de81e94921/relationships/campaigns"
+                    }
+                },
+                "EmailAddress": {
+                    "links": {
+                        "related": "V8/module/Contacts/bea511d3-c7a7-4097-55ed-68de81e94921/relationships/email_addresses"
+                    }
+                },
+                "IATI_Datasets": {
+                    "links": {
+                        "related": "V8/module/Contacts/bea511d3-c7a7-4097-55ed-68de81e94921/relationships/contact_iati_datasets"
+                    }
+                },
+                "Opportunities": {
+                    "links": {
+                        "related": "V8/module/Contacts/bea511d3-c7a7-4097-55ed-68de81e94921/relationships/opportunities"
+                    }
+                },
+                "Project": {
+                    "links": {
+                        "related": "V8/module/Contacts/bea511d3-c7a7-4097-55ed-68de81e94921/relationships/project_contacts_1"
+                    }
+                },
+                "ProspectLists": {
+                    "links": {
+                        "related": "V8/module/Contacts/bea511d3-c7a7-4097-55ed-68de81e94921/relationships/prospect_lists"
+                    }
+                },
+                "SecurityGroups": {
+                    "links": {
+                        "related": "V8/module/Contacts/bea511d3-c7a7-4097-55ed-68de81e94921/relationships/SecurityGroups"
+                    }
+                },
+                "Users": {
+                    "links": {
+                        "related": "V8/module/Contacts/bea511d3-c7a7-4097-55ed-68de81e94921/relationships/created_by_link"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tests/helpers/mocking.py
+++ b/tests/helpers/mocking.py
@@ -4,6 +4,7 @@ import logging
 import os
 import time
 from typing import AsyncIterator
+from unittest import mock
 from uuid import UUID
 
 import jwt
@@ -304,6 +305,14 @@ def make_test_context(app_and_context: MockedAppAndContext) -> util.Context:
     test_context._setup_loggers()
 
     test_context._setup_key_store()
+
+    test_context._email_address_for_iati_support_approvals = "example@example.com"
+    test_context._email_generator = mock.MagicMock()
+    test_context._email_sender = mock.MagicMock()
+    test_context._email_sender_ryd_from_name = "IATI Registry"
+    test_context._email_sender_ryd_from_email = "example@example.com"
+
+    test_context._iati_account_instance_base_url = "https://account.iatistandard.org"
 
     # Add sqlite FGA provider and populate with test values
     if os.path.isfile("test.db"):

--- a/tests/helpers/mocking.py
+++ b/tests/helpers/mocking.py
@@ -309,7 +309,7 @@ def make_test_context(app_and_context: MockedAppAndContext) -> util.Context:
     test_context._email_address_for_iati_support_approvals = "example@example.com"
     test_context._email_generator = mock.MagicMock()
     test_context._email_sender = mock.MagicMock()
-    test_context._email_sender_ryd_from_name = "IATI Registry"
+    test_context._email_sender_ryd_from_name = "IATI Register Your Data"
     test_context._email_sender_ryd_from_email = "example@example.com"
 
     test_context._iati_account_instance_base_url = "https://account.iatistandard.org"

--- a/tests/helpers/utilities.py
+++ b/tests/helpers/utilities.py
@@ -5,10 +5,10 @@ from typing import Any
 
 def find_record_in_response(resp_as_object: dict[str, Any], record_id: str) -> dict[str, Any] | None:
     """Finds a record with the given ID in the response object."""
-
-    for record in resp_as_object["data"]:
+    records: list[dict[str, Any]] = resp_as_object["data"]
+    for record in records:
         if record["id"] == record_id:
-            return record  # type: ignore
+            return record
     return None
 
 

--- a/tests/integration/.env
+++ b/tests/integration/.env
@@ -1,8 +1,16 @@
-JWKS_URI = "https://example.org/jwks"
 APP_LOG_LEVEL = "DEBUG"
 APP_LOG_PATH = ""
 AUDIT_LOG_PATH = ""
 AUDIT_LOG_PUBLIC_KEY_PATH = ""
+
+EMAIL_TEMPLATES_DIR="email_templates"
+
+EMAIL_ADDRESS_FOR_IATI_SUPPORT_APPROVALS=""
+
 PROMETHEUS_PORT = 1111
+
 OIDC_CONNECT_URL = "https://example.org/.well-known/openid-configuration"
+
+JWKS_URI = "https://example.org/jwks"
+
 JWT_AUDIENCE = "iati_register_your_data"

--- a/tests/integration/test_fga_provider_pgdb.py
+++ b/tests/integration/test_fga_provider_pgdb.py
@@ -75,3 +75,46 @@ def test_assignment_of_permissions() -> None:
     perm_check = fga.get_user_fine_grained_permissions(user3)
     assert len(perm_check) == 0
     assert fga.is_user_a_superadmin(user3) is True
+
+
+def test_fga_fetch_admins() -> None:
+    """Simple test of FGA provider DB using SQLite in-memory DB"""
+
+    fga = FineGrainedAuthorisationProviderDb("sqlite:///:memory:")
+    fga.setup()
+    sqlmodel.SQLModel.metadata.create_all(fga._engine)
+
+    u1, u2, u3 = uuid4(), uuid4(), uuid4()
+    o1, o2 = uuid4(), uuid4()
+
+    with sqlmodel.Session(fga._engine) as session:
+        session.add(
+            FineGrainedAuthorisationDbModel(
+                user=u1, reporting_org=o1, role=FineGrainedAuthorisationRole.EDITOR, id=uuid4()
+            )
+        )
+        session.add(
+            FineGrainedAuthorisationDbModel(
+                user=u1, reporting_org=o2, role=FineGrainedAuthorisationRole.CONTRIBUTOR, id=uuid4()
+            )
+        )
+
+        session.add(
+            FineGrainedAuthorisationDbModel(
+                user=u2, reporting_org=o1, role=FineGrainedAuthorisationRole.ADMIN, id=uuid4()
+            )
+        )
+        session.add(
+            FineGrainedAuthorisationDbModel(
+                user=u3, reporting_org=o1, role=FineGrainedAuthorisationRole.ADMIN, id=uuid4()
+            )
+        )
+        session.commit()
+
+    fga_admins_org_1 = fga.get_admin_users_for_org(o1)
+
+    assert len(fga_admins_org_1) == 2
+
+    fga_admins_org_2 = fga.get_admin_users_for_org(o2)
+
+    assert len(fga_admins_org_2) == 0

--- a/tests/unit/test_email_generator.py
+++ b/tests/unit/test_email_generator.py
@@ -1,0 +1,97 @@
+import re
+from pathlib import Path
+
+from register_your_data_api.email_generator import Email, EmailGenerator, EmailType
+
+
+def _template_variables(template_path: Path) -> list[str]:
+    template_text = template_path.read_text(encoding="utf-8")
+    return re.findall(r"{{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*}}", template_text)
+
+
+def _assert_template_variables_replaced(content: str, template_path: Path, values: dict[str, str]) -> None:
+    for variable in _template_variables(template_path):
+        assert variable in values
+        assert values[variable] in content
+
+
+def test_generate_email_content_user_requested_to_join_org() -> None:
+    templates_dir = Path(__file__).resolve().parents[2] / "email_templates"
+    generator = EmailGenerator(str(templates_dir))
+
+    template_values = {
+        "from_name": "IATI Registry",
+        "from_email": "support@iatistandard.org",
+        "to_name": "Alex Admin",
+        "to_email": "alex.admin@example.org",
+        "user_requesting_join_name": "Sam User",
+        "user_requesting_join_email": "sam.user@example.org",
+        "org_name": "Example Org",
+        "site_url": "https://account.iatistandard.org",
+        "org_id": "EX-123",
+    }
+
+    result = generator.generate_email_content(
+        EmailType.USER_REQUESTED_TO_JOIN_ORG,
+        **template_values,
+    )
+
+    assert isinstance(result, Email)
+    _assert_template_variables_replaced(
+        result.subject,
+        templates_dir / "user_requested_to_join_org_subject.txt",
+        template_values,
+    )
+    _assert_template_variables_replaced(
+        result.content_text,
+        templates_dir / "user_requested_to_join_org.txt",
+        template_values,
+    )
+    _assert_template_variables_replaced(
+        result.content_html,
+        templates_dir / "user_requested_to_join_org.html",
+        template_values,
+    )
+
+
+def test_generate_email_content_new_org_needs_approval() -> None:
+    templates_dir = Path(__file__).resolve().parents[2] / "email_templates"
+    generator = EmailGenerator(str(templates_dir))
+
+    template_values = {
+        "from_name": "IATI Registry",
+        "from_email": "support@iatistandard.org",
+        "to_name": "IATI Support Team",
+        "to_email": "support@iatistandard.org",
+        "org_name": "Example Org",
+        "org_short_name": "example-org",
+        "org_human_readable_name": "Example Organisation",
+        "org_id": "EX-123",
+        "site_url": "https://account.iatistandard.org",
+        "user_name": "Alex Admin",
+        "user_email": "alex.admin@example.org",
+        "user_id": "USER-456",
+        "creation_date": "2026-01-28",
+    }
+
+    result = generator.generate_email_content(
+        EmailType.NEW_ORG_NEEDS_APPROVAL,
+        **template_values,
+    )
+
+    assert isinstance(result, Email)
+    _assert_template_variables_replaced(
+        result.subject,
+        templates_dir / "new_org_needs_approval_subject.txt",
+        template_values,
+    )
+    _assert_template_variables_replaced(
+        result.content_text,
+        templates_dir / "new_org_needs_approval.txt",
+        template_values,
+    )
+    _assert_template_variables_replaced(
+        result.content_html,
+        templates_dir / "new_org_needs_approval.html",
+        template_values,
+    )

--- a/tests/unit/test_email_generator.py
+++ b/tests/unit/test_email_generator.py
@@ -20,15 +20,15 @@ def test_generate_email_content_user_requested_to_join_org() -> None:
     generator = EmailGenerator(str(templates_dir))
 
     template_values = {
-        "from_name": "IATI Registry",
+        "from_name": "IATI Register Your Data",
         "from_email": "support@iatistandard.org",
         "to_name": "Alex Admin",
         "to_email": "alex.admin@example.org",
         "user_requesting_join_name": "Sam User",
         "user_requesting_join_email": "sam.user@example.org",
-        "org_name": "Example Org",
+        "org_id": "8aa43b78-bcea-4cef-9113-5bb4f0fa7140",
+        "org_human_readable_name": "Example Org",
         "site_url": "https://account.iatistandard.org",
-        "org_id": "EX-123",
     }
 
     result = generator.generate_email_content(
@@ -59,14 +59,13 @@ def test_generate_email_content_new_org_needs_approval() -> None:
     generator = EmailGenerator(str(templates_dir))
 
     template_values = {
-        "from_name": "IATI Registry",
+        "from_name": "IATI Register Your Data",
         "from_email": "support@iatistandard.org",
         "to_name": "IATI Support Team",
         "to_email": "support@iatistandard.org",
-        "org_name": "Example Org",
         "org_short_name": "example-org",
         "org_human_readable_name": "Example Organisation",
-        "org_id": "EX-123",
+        "org_id": "69626e79-122b-492b-abbe-d7c7dc519329",
         "site_url": "https://account.iatistandard.org",
         "user_name": "Alex Admin",
         "user_email": "alex.admin@example.org",


### PR DESCRIPTION
This PR:
* Refactors `add_user_to_org` to use `assert_precondition_met`, and begins to unify the format of the audit and app logs
* Stops users from being able to attempt to join the same organisation twice (resolving #60)
* Adds jinja for email templating, pytest-watcher for easier developing, Azure Email Communication Service library, and email validation libraries
* Adds an `EmailGenerator` class for generating emails from templates
* Adds a background worker processor, and email sending function
* Modifies `create_reporting_org` to notify Support upon reporting org creation (resolving #50)
* Modifies `add_user_to_org` to notify org admin when someone joins an org (resolving #49)

**Note: this PR adds several new environment variables, so the salt deployment infrastructure will need updating before this is deployed.**