### PR TITLE
Prevent deletion of last user from a reporting organisation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "register-your-data-api"
-version = "0.3.1"
+version = "0.3.2"
 requires-python = ">= 3.12.11"
 readme = "README.md"
 authors = [{name="IATI Secretariat", email="support@iatistandard.org"}]

--- a/src/register_your_data_api/dependencies.py
+++ b/src/register_your_data_api/dependencies.py
@@ -21,7 +21,8 @@ def get_suitecrm_audit_headers(
     except ValueError as e:
         trace_id = uuid.uuid4()
         raise RYDUserException(
-            user,
+            user.user_id_crm,
+            user.client_id,
             400,
             f"trace_id: {trace_id} - details: unknown client ID",
             f"trace_id: {trace_id} - details: {e.args[0]}",

--- a/src/register_your_data_api/exception_handlers.py
+++ b/src/register_your_data_api/exception_handlers.py
@@ -4,18 +4,19 @@ import starlette.exceptions
 from fastapi.exceptions import RequestValidationError
 from starlette.requests import Request
 
-from .auth.models import UserAndCredentials
 from .exceptions import RYDUserException  # noqa: F401
 from .util import Context  # noqa: F401
 
 
 def format_log_msg(
-    request: Request, user: UserAndCredentials, msg: str | None, include_client_id: bool = False
+    request: Request, user_id: str | None, client_id: str | None, msg: str | None, include_client_id: bool = False
 ) -> str | None:
     if msg is None:
         return None
-    client_prefix: str = f"client id: {user.client_id} - " if include_client_id else ""
-    return client_prefix + f"user id: {user.user_id_crm} - " f"{request.method} {request.url.path} - {msg}"
+
+    client_prefix: str = f"client id: {client_id} - " if include_client_id else ""
+
+    return client_prefix + f"user id: {user_id} - {request.method} {request.url.path} - {msg}"
 
 
 async def ryd_user_exception_handler(request: Request, exc: RYDUserException) -> fastapi.responses.JSONResponse:
@@ -36,9 +37,9 @@ async def ryd_user_exception_handler(request: Request, exc: RYDUserException) ->
 
     context: Context = request.app.state.context
 
-    app_log_msg = format_log_msg(request, exc.user, exc.app_msg)
+    app_log_msg = format_log_msg(request, exc.user_id, exc.client_id, exc.app_msg)
 
-    audit_log_msg = format_log_msg(request, exc.user, exc.audit_msg, include_client_id=True)
+    audit_log_msg = format_log_msg(request, exc.user_id, exc.client_id, exc.audit_msg, include_client_id=True)
 
     if app_log_msg is not None:
         context.app_logger.error(app_log_msg)

--- a/src/register_your_data_api/exceptions.py
+++ b/src/register_your_data_api/exceptions.py
@@ -1,6 +1,3 @@
-from .auth.models import UserAndCredentials
-
-
 class RYDException(Exception):
     """Base class for all app errors."""
 
@@ -12,13 +9,15 @@ class RYDUserException(RYDException):
 
     def __init__(
         self,
-        user: UserAndCredentials,
+        user_id: str | None,
+        client_id: str | None,
         status_code: int,
         app_msg: str | None,
         audit_msg: str | None,
         public_msg: str | None,
     ):
-        self.user: UserAndCredentials = user
+        self.user_id: str | None = user_id
+        self.client_id: str | None = client_id
         self.status_code: int = status_code
         self.app_msg: str | None = app_msg
         self.audit_msg: str | None = audit_msg

--- a/src/register_your_data_api/routers/datasets.py
+++ b/src/register_your_data_api/routers/datasets.py
@@ -49,7 +49,8 @@ def create_dataset(
     # Check the user has permission to create datasets for the specified
     # reporting org
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: user.validator.user_can_create_reporting_org_datasets(
             uuid.UUID(dataset.owner_organisation_id)
         ),
@@ -68,7 +69,8 @@ def create_dataset(
     # the case for superadmins, so permission to create datasets for a reporting
     # org does not imply that the reporting org exists, so we check that here
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: check_crm_record_exists(crm, "Accounts", str(dataset.owner_organisation_id)),
         status_code=fastapi.status.HTTP_404_NOT_FOUND,
         audit_log_msg=(
@@ -80,7 +82,8 @@ def create_dataset(
 
     # Check that the short name is unique
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: get_num_crm_records(crm, "IATI_Datasets", {"iati_short_name": dataset.short_name}) == 0,
         status_code=fastapi.status.HTTP_409_CONFLICT,
         audit_log_msg=(
@@ -135,7 +138,8 @@ def get_dataset_detail(
 
     # Check that the dataset exists and is unique
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: len(datasets) == 1,
         status_code=fastapi.status.HTTP_404_NOT_FOUND,
         audit_log_msg=(
@@ -191,7 +195,8 @@ def update_dataset(
     )
 
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: len(original_dataset_record_from_suitecrm["data"]) != 0,
         status_code=fastapi.status.HTTP_404_NOT_FOUND,
         audit_log_msg=(
@@ -206,7 +211,8 @@ def update_dataset(
     owning_reporting_org = original_dataset_record_from_suitecrm["data"][0]["attributes"]["iati_dataset_owner_org_id"]
 
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: user.validator.user_can_update_reporting_org_datasets(uuid.UUID(owning_reporting_org)),
         status_code=fastapi.status.HTTP_403_FORBIDDEN,
         audit_log_msg=(
@@ -223,7 +229,8 @@ def update_dataset(
     dataset_for_suitecrm = get_suitecrm_dict_from_dataset(dataset)
 
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: (
             user.validator.user_can_update_reporting_org_dataset_visibility(owning_reporting_org)
             or dataset.visibility is None
@@ -245,7 +252,8 @@ def update_dataset(
 
     # Check that the short name is unique
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: (
             original_dataset_record_from_suitecrm["data"][0]["attributes"]["iati_short_name"] == dataset.short_name
             or (
@@ -311,7 +319,8 @@ def delete_dataset(
     )
 
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: len(original_dataset_record_from_suitecrm["data"]) == 1,
         status_code=fastapi.status.HTTP_404_NOT_FOUND,
         public_msg=f"There is no dataset with ID {str(dataset_id)} in the Registry.",
@@ -320,7 +329,8 @@ def delete_dataset(
     owning_reporting_org = original_dataset_record_from_suitecrm["data"][0]["attributes"]["iati_dataset_owner_org_id"]
 
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: user.validator.user_can_delete_reporting_org_datasets(uuid.UUID(owning_reporting_org)),
         status_code=fastapi.status.HTTP_403_FORBIDDEN,
         public_msg=(

--- a/src/register_your_data_api/routers/datasets.py
+++ b/src/register_your_data_api/routers/datasets.py
@@ -49,7 +49,6 @@ def create_dataset(
     # Check the user has permission to create datasets for the specified
     # reporting org
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: user.validator.user_can_create_reporting_org_datasets(
             uuid.UUID(dataset.owner_organisation_id)
@@ -69,7 +68,6 @@ def create_dataset(
     # the case for superadmins, so permission to create datasets for a reporting
     # org does not imply that the reporting org exists, so we check that here
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: check_crm_record_exists(crm, "Accounts", str(dataset.owner_organisation_id)),
         status_code=fastapi.status.HTTP_404_NOT_FOUND,
@@ -82,7 +80,6 @@ def create_dataset(
 
     # Check that the short name is unique
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: get_num_crm_records(crm, "IATI_Datasets", {"iati_short_name": dataset.short_name}) == 0,
         status_code=fastapi.status.HTTP_409_CONFLICT,
@@ -137,7 +134,6 @@ def get_dataset_detail(
 
     # Check that the dataset exists and is unique
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: len(datasets) == 1,
         status_code=fastapi.status.HTTP_404_NOT_FOUND,
@@ -194,7 +190,6 @@ def update_dataset(
     )
 
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: len(original_dataset_record_from_suitecrm["data"]) != 0,
         status_code=fastapi.status.HTTP_404_NOT_FOUND,
@@ -210,7 +205,6 @@ def update_dataset(
     owning_reporting_org = original_dataset_record_from_suitecrm["data"][0]["attributes"]["iati_dataset_owner_org_id"]
 
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: user.validator.user_can_update_reporting_org_datasets(uuid.UUID(owning_reporting_org)),
         status_code=fastapi.status.HTTP_403_FORBIDDEN,
@@ -228,7 +222,6 @@ def update_dataset(
     dataset_for_suitecrm = get_suitecrm_dict_from_dataset(dataset)
 
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: (
             user.validator.user_can_update_reporting_org_dataset_visibility(owning_reporting_org)
@@ -251,7 +244,6 @@ def update_dataset(
 
     # Check that the short name is unique
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: (
             original_dataset_record_from_suitecrm["data"][0]["attributes"]["iati_short_name"] == dataset.short_name
@@ -317,7 +309,6 @@ def delete_dataset(
     )
 
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: len(original_dataset_record_from_suitecrm["data"]) == 1,
         status_code=fastapi.status.HTTP_404_NOT_FOUND,
@@ -327,7 +318,6 @@ def delete_dataset(
     owning_reporting_org = original_dataset_record_from_suitecrm["data"][0]["attributes"]["iati_dataset_owner_org_id"]
 
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: user.validator.user_can_delete_reporting_org_datasets(uuid.UUID(owning_reporting_org)),
         status_code=fastapi.status.HTTP_403_FORBIDDEN,

--- a/src/register_your_data_api/routers/datasets.py
+++ b/src/register_your_data_api/routers/datasets.py
@@ -101,7 +101,8 @@ def create_dataset(
     context.audit_logger.info(
         format_log_msg(
             request,
-            user,
+            user.user_id_crm,
+            user.client_id,
             f"trace id: {trace_id} - Created dataset with id: {suitecrm_dataset['id']}",
             include_client_id=True,
         )
@@ -272,7 +273,8 @@ def update_dataset(
     context.audit_logger.info(
         format_log_msg(
             request,
-            user,
+            user.user_id_crm,
+            user.client_id,
             f"trace id: {trace_id} - Created dataset with id: {suitecrm_dataset['id']}",
             include_client_id=True,
         )
@@ -337,7 +339,8 @@ def delete_dataset(
         context.audit_logger.info(
             format_log_msg(
                 request,
-                user,
+                user.user_id_crm,
+                user.client_id,
                 f"trace id: {trace_id} - Deleted dataset with id: {str(dataset_id)}",
                 include_client_id=True,
             )

--- a/src/register_your_data_api/routers/reporting_orgs.py
+++ b/src/register_your_data_api/routers/reporting_orgs.py
@@ -76,7 +76,8 @@ def get_reporting_org_detail(
     context: Context = request.app.state.context
 
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: user.validator.user_can_read_reporting_org(org_id),
         status_code=fastapi.status.HTTP_403_FORBIDDEN,
         audit_log_msg=(f"Request to get reporting org details for org id: {org_id} by unauthorised user"),
@@ -101,7 +102,8 @@ def get_reporting_org_detail(
     # a user could have a role for an org that doesn't exist or isn't discoverable, so we handle that here. We don't
     # run this check first to avoid making unnecessary CRM calls in the majority of cases.
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: len(crm_reporting_orgs["data"]) > 0,
         status_code=fastapi.status.HTTP_404_NOT_FOUND,
         audit_log_msg=(f"Request to get reporting org details failed for org id: {org_id} as it doesn't exist"),
@@ -136,7 +138,8 @@ def create_reporting_org(
     trace_id: uuid.UUID = uuid.uuid4()
 
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: user.validator.user_can_create_reporting_org(),
         status_code=fastapi.status.HTTP_403_FORBIDDEN,
         audit_log_msg=(f"Request to create reporting org by unauthorised user id: {user.user_id_crm}"),
@@ -152,7 +155,8 @@ def create_reporting_org(
 
     # Check that the short name is unique
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: get_num_crm_records(
             crm, "Accounts", {"iati_short_name": reporting_org.short_name, "iati_registry_discoverable": 1}
         )
@@ -370,7 +374,8 @@ def delete_reporting_org(
 
     # 1. Check that the user has permissions to delete (mark as not on RYD) the reporting org
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: user.validator.user_can_delete_reporting_org(org_id),
         status_code=fastapi.status.HTTP_403_FORBIDDEN,
         audit_log_msg=(
@@ -398,7 +403,8 @@ def delete_reporting_org(
     )
 
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: len(crm_reporting_org["data"]) == 1,
         status_code=fastapi.status.HTTP_404_NOT_FOUND,
         public_msg=f"There is no organisation with ID {str(org_id)} in the Registry.",
@@ -553,7 +559,8 @@ def get_reporting_org_datasets(
 
     # 1. Check that the user has permissions to read datasets for the reporting org
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: user.validator.user_can_read_reporting_org_datasets(org_id),
         status_code=fastapi.status.HTTP_403_FORBIDDEN,
         audit_log_msg=(
@@ -570,7 +577,8 @@ def get_reporting_org_datasets(
 
     # 2. Check that the Reporting Org exists in the CRM
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: check_crm_record_exists(crm, "Accounts", str(org_id)),
         status_code=fastapi.status.HTTP_404_NOT_FOUND,
         public_msg=f"There is no organisation with ID {str(org_id)} in the Registry.",

--- a/src/register_your_data_api/routers/reporting_orgs.py
+++ b/src/register_your_data_api/routers/reporting_orgs.py
@@ -76,7 +76,6 @@ def get_reporting_org_detail(
     context: Context = request.app.state.context
 
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: user.validator.user_can_read_reporting_org(org_id),
         status_code=fastapi.status.HTTP_403_FORBIDDEN,
@@ -102,7 +101,6 @@ def get_reporting_org_detail(
     # a user could have a role for an org that doesn't exist or isn't discoverable, so we handle that here. We don't
     # run this check first to avoid making unnecessary CRM calls in the majority of cases.
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: len(crm_reporting_orgs["data"]) > 0,
         status_code=fastapi.status.HTTP_404_NOT_FOUND,
@@ -138,7 +136,6 @@ def create_reporting_org(
     trace_id: uuid.UUID = uuid.uuid4()
 
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: user.validator.user_can_create_reporting_org(),
         status_code=fastapi.status.HTTP_403_FORBIDDEN,
@@ -155,7 +152,6 @@ def create_reporting_org(
 
     # Check that the short name is unique
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: get_num_crm_records(
             crm, "Accounts", {"iati_short_name": reporting_org.short_name, "iati_registry_discoverable": 1}
@@ -366,7 +362,6 @@ def delete_reporting_org(
 
     # 1. Check that the user has permissions to delete (mark as not on RYD) the reporting org
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: user.validator.user_can_delete_reporting_org(org_id),
         status_code=fastapi.status.HTTP_403_FORBIDDEN,
@@ -395,7 +390,6 @@ def delete_reporting_org(
     )
 
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: len(crm_reporting_org["data"]) == 1,
         status_code=fastapi.status.HTTP_404_NOT_FOUND,
@@ -545,7 +539,6 @@ def get_reporting_org_datasets(
 
     # 1. Check that the user has permissions to read datasets for the reporting org
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: user.validator.user_can_read_reporting_org_datasets(org_id),
         status_code=fastapi.status.HTTP_403_FORBIDDEN,
@@ -563,7 +556,6 @@ def get_reporting_org_datasets(
 
     # 2. Check that the Reporting Org exists in the CRM
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: check_crm_record_exists(crm, "Accounts", str(org_id)),
         status_code=fastapi.status.HTTP_404_NOT_FOUND,

--- a/src/register_your_data_api/routers/reporting_orgs.py
+++ b/src/register_your_data_api/routers/reporting_orgs.py
@@ -221,7 +221,8 @@ def create_reporting_org(
             user_email = crm_user["data"][0]["attributes"]["email1"]
         else:
             raise RYDUserException(
-                user=user,
+                user_id=user.user_id_crm,
+                client_id=user.client_id,
                 status_code=400,
                 app_msg=(
                     f"trace id: {trace_id} - User account details for user id: {user.user_id_crm} "
@@ -256,7 +257,8 @@ def create_reporting_org(
     context.audit_logger.info(
         format_log_msg(
             request,
-            user,
+            user.user_id_crm,
+            user.client_id,
             f"trace id: {trace_id} - Created reporting org with id: {suitecrm_reporting_org['id']}",
             include_client_id=True,
         )
@@ -344,7 +346,13 @@ def update_reporting_org(
     )
 
     context.audit_logger.info(
-        format_log_msg(request, user, f"Updated reporting org with id: {str(org_id)}", include_client_id=True)
+        format_log_msg(
+            request,
+            user.user_id_crm,
+            user.client_id,
+            f"Updated reporting org with id: {str(org_id)}",
+            include_client_id=True,
+        )
     )
 
     return UserReportingOrgRelationSingleResponse(status="success", error=None, data=user_reporting_org_relation)
@@ -441,7 +449,13 @@ def delete_reporting_org(
         )
 
     context.audit_logger.info(
-        format_log_msg(request, user, f"Deleted reporting org with id: {str(org_id)}", include_client_id=True)
+        format_log_msg(
+            request,
+            user.user_id_crm,
+            user.client_id,
+            f"Deleted reporting org with id: {str(org_id)}",
+            include_client_id=True,
+        )
     )
 
     return fastapi.responses.JSONResponse({"status": "success", "data": None, "error": None})

--- a/src/register_your_data_api/routers/users.py
+++ b/src/register_your_data_api/routers/users.py
@@ -57,7 +57,8 @@ def add_user_to_reporting_org(
     user_id_to_add_as_str = str(user_id)
 
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: user_id_to_add_as_str == user.user_id_crm,
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,
         public_msg=("You cannot request a different user to join a reporting organisation."),
@@ -69,7 +70,8 @@ def add_user_to_reporting_org(
 
     # Superadmins shouldn't be allowed to join any organisations
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: not user.validator.is_superadmin,
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,
         public_msg=("Superadmins cannot join organisations."),
@@ -86,7 +88,8 @@ def add_user_to_reporting_org(
 
     # Check the reporting org exists
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: len(org_response["data"]) == 1,
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,
         public_msg=(f"There is no organisation with ID {payload.oid_str} in the Registry."),
@@ -97,7 +100,8 @@ def add_user_to_reporting_org(
 
     # Check the user isn't already a member of that organisation
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: user.validator.get_user_role_for_reporting_org(payload.oid) is None,
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,
         public_msg=(f"You are already associated with that reporting org id: {payload.oid_str}."),
@@ -240,7 +244,8 @@ def get_reporting_orgs(
 
     # 1. Check that the requested user exists in CRM
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: check_crm_record_exists(crm, "Contacts", str(user_id)),
         public_msg=f"There is no user with ID {str(user_id)}.",
         status_code=fastapi.status.HTTP_404_NOT_FOUND,
@@ -252,7 +257,8 @@ def get_reporting_orgs(
 
     # 2. Check that the user has permission to the the requested user's reporting orgs
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: user.validator.user_can_read_users_reporting_orgs(user_id),
         status_code=fastapi.status.HTTP_403_FORBIDDEN,
         public_msg=(
@@ -285,7 +291,8 @@ def update_user_role_in_reporting_org(
 
     # 1. Check if the requesting user has permission to update roles for this org
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: user.validator.user_can_modify_user_roles_for_reporting_org(org_id),
         status_code=fastapi.status.HTTP_403_FORBIDDEN,
         public_msg=(
@@ -303,7 +310,8 @@ def update_user_role_in_reporting_org(
 
     # 2. Check that the target user exists in CRM
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: check_crm_record_exists(crm, "Contacts", str(user_id)),
         public_msg=f"There is no user with ID {str(user_id)} in the Registry.",
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,
@@ -318,7 +326,8 @@ def update_user_role_in_reporting_org(
 
     # 4. Check that the reporting org exists in CRM
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: check_crm_record_exists(crm, "Accounts", str(org_id)),
         public_msg=f"There is no organisation with ID {str(org_id)} in the Registry.",
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,
@@ -332,7 +341,8 @@ def update_user_role_in_reporting_org(
     # code does not find a relationship between the target user and the reporting org in the CRM, or a role
     # in the FGA database, it will try to create them, but this must not be allowed for superadmins
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: not context.fine_grained_auth_provider.is_user_a_superadmin(user_id),
         public_msg=f"User id: {user_id} cannot be given a role in no organisation with ID {str(org_id)}.",
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,
@@ -427,7 +437,8 @@ def remove_user_from_reporting_org(
 
     # 1. Check if the requesting user has permission to update roles for this org
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: user.validator.user_can_modify_user_roles_for_reporting_org(org_id),
         status_code=fastapi.status.HTTP_403_FORBIDDEN,
         public_msg=(
@@ -445,7 +456,8 @@ def remove_user_from_reporting_org(
 
     # 2. Check that the target user exists in CRM
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: check_crm_record_exists(crm, "Contacts", str(user_id)),
         public_msg=f"There is no user with ID {str(user_id)} in the Registry.",
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,
@@ -457,7 +469,8 @@ def remove_user_from_reporting_org(
 
     # 3. Check that the reporting org exists in CRM
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: check_crm_record_exists(crm, "Accounts", str(org_id)),
         public_msg=f"There is no organisation with ID {str(org_id)} in the Registry.",
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,
@@ -470,7 +483,8 @@ def remove_user_from_reporting_org(
     user_role_for_org = context.fine_grained_auth_provider.get_user_role_for_org(user_id, org_id)
 
     assert_precondition_met(
-        user,
+        user.user_id_crm,
+        user.client_id,
         condition_func=lambda: user_role_for_org is not None,
         public_msg=f"User id: {user_id} has no role in organisation with id: {str(org_id)} in the Registry.",
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,

--- a/src/register_your_data_api/routers/users.py
+++ b/src/register_your_data_api/routers/users.py
@@ -11,13 +11,16 @@ from fastapi.responses import JSONResponse
 from libsuitecrm import Filter, SuiteCRM  # type: ignore
 
 from register_your_data_api import email_generator
+from register_your_data_api.auth.fga.models import (
+    FineGrainedAuthorisationRole,
+    FineGrainedAuthorisationRoleAssociation,
+)
 from register_your_data_api.background_tasks import ActionType, enqueue_task
 from register_your_data_api.dependencies import get_suitecrm_audit_headers
 from register_your_data_api.response_schemas import PaginatedResultsPage
 from register_your_data_api.services.suitecrm_common import get_reporting_orgs_for_user
 
 from ..auth import authz
-from ..auth.fga import models as fga_models
 from ..auth.models import UserAndCredentials
 from ..data_handling.converters import get_fga_role_from_str
 from ..data_handling.data_schemas import (
@@ -144,10 +147,10 @@ def add_user_to_reporting_org(
         )
 
         # 2. Create a fine-grained authorisation for this user to be CONTRIBUTOR_PENDING of new reporting_org
-        user_reporting_org_role = fga_models.FineGrainedAuthorisationRoleAssociation(
+        user_reporting_org_role = FineGrainedAuthorisationRoleAssociation(
             user=uuid.UUID(user.user_id_crm),
             reporting_org=payload.oid,
-            role=fga_models.FineGrainedAuthorisationRole.CONTRIBUTOR_PENDING,
+            role=FineGrainedAuthorisationRole.CONTRIBUTOR_PENDING,
         )
         context.fine_grained_auth_provider.create_user_fine_grained_authorisation(user_reporting_org_role)
 
@@ -387,7 +390,7 @@ def update_user_role_in_reporting_org(
             "Creating new entry in the FGA database."
         )
 
-        user_role_for_org = fga_models.FineGrainedAuthorisationRoleAssociation(
+        user_role_for_org = FineGrainedAuthorisationRoleAssociation(
             user=user_id,
             reporting_org=org_id,
             role=get_fga_role_from_str(new_role.role),
@@ -494,7 +497,45 @@ def remove_user_from_reporting_org(
         ),
     )
 
-    # 4. Delete the user's role in the FGA database
+    # 4a. Check that the user isn't the last user in the organisation
+    users_in_org = context.fine_grained_auth_provider.get_user_associations_for_org(org_id)
+
+    assert_precondition_met(
+        user.user_id_crm,
+        user.client_id,
+        condition_func=lambda: len(users_in_org) > 1,
+        public_msg=(
+            f"User id: {user_id} is the last user associated with "
+            f"organisation id: {org_id} so cannot be removed from the organisation."
+        ),
+        status_code=fastapi.status.HTTP_400_BAD_REQUEST,
+        audit_log_msg=(
+            f"Unexpected error: user with id: {user.user_id_crm} attempted to remove user id: {user_id}'s role in "
+            f"organisation with id: {org_id} but the user is the last user associated with the organisation. "
+        ),
+    )
+
+    # 4b. Check that the user isn't the last admin user for this organisation
+    number_admins = len(list(filter(lambda x: x.role == FineGrainedAuthorisationRole.ADMIN, users_in_org)))
+
+    assert_precondition_met(
+        user.user_id_crm,
+        user.client_id,
+        condition_func=lambda: not (
+            user_role_for_org.role == FineGrainedAuthorisationRole.ADMIN and number_admins == 1  # type: ignore
+        ),
+        public_msg=(
+            f"User id: {user_id} is the last admin user associated with "
+            f"organisation id: {org_id} so cannot be removed from the organisation."
+        ),
+        status_code=fastapi.status.HTTP_400_BAD_REQUEST,
+        audit_log_msg=(
+            f"Unexpected error: user with id: {user.user_id_crm} attempted to remove user id: {user_id}'s role in "
+            f"organisation with id: {org_id} but the user is the last admin user associated with the organisation."
+        ),
+    )
+
+    # 5. Delete the user's role in the FGA database
     try:
         context.fine_grained_auth_provider.delete_user_role_for_org(user_role_for_org)  # type: ignore
 

--- a/src/register_your_data_api/routers/users.py
+++ b/src/register_your_data_api/routers/users.py
@@ -57,7 +57,6 @@ def add_user_to_reporting_org(
     user_id_to_add_as_str = str(user_id)
 
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: user_id_to_add_as_str == user.user_id_crm,
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,
@@ -70,7 +69,6 @@ def add_user_to_reporting_org(
 
     # Superadmins shouldn't be allowed to join any organisations
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: not user.validator.is_superadmin,
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,
@@ -88,7 +86,6 @@ def add_user_to_reporting_org(
 
     # Check the reporting org exists
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: len(org_response["data"]) == 1,
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,
@@ -100,7 +97,6 @@ def add_user_to_reporting_org(
 
     # Check the user isn't already a member of that organisation
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: user.validator.get_user_role_for_reporting_org(payload.oid) is None,
         status_code=fastapi.status.HTTP_400_BAD_REQUEST,
@@ -240,7 +236,6 @@ def get_reporting_orgs(
 
     # 1. Check that the requested user exists in CRM
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: check_crm_record_exists(crm, "Contacts", str(user_id)),
         public_msg=f"There is no user with ID {str(user_id)}.",
@@ -253,7 +248,6 @@ def get_reporting_orgs(
 
     # 2. Check that the user has permission to the the requested user's reporting orgs
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: user.validator.user_can_read_users_reporting_orgs(user_id),
         status_code=fastapi.status.HTTP_403_FORBIDDEN,
@@ -287,7 +281,6 @@ def update_user_role_in_reporting_org(
 
     # 1. Check if the requesting user has permission to update roles for this org
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: user.validator.user_can_modify_user_roles_for_reporting_org(org_id),
         status_code=fastapi.status.HTTP_403_FORBIDDEN,
@@ -306,7 +299,6 @@ def update_user_role_in_reporting_org(
 
     # 2. Check that the target user exists in CRM
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: check_crm_record_exists(crm, "Contacts", str(user_id)),
         public_msg=f"There is no user with ID {str(user_id)} in the Registry.",
@@ -322,7 +314,6 @@ def update_user_role_in_reporting_org(
 
     # 4. Check that the reporting org exists in CRM
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: check_crm_record_exists(crm, "Accounts", str(org_id)),
         public_msg=f"There is no organisation with ID {str(org_id)} in the Registry.",
@@ -337,7 +328,6 @@ def update_user_role_in_reporting_org(
     # code does not find a relationship between the target user and the reporting org in the CRM, or a role
     # in the FGA database, it will try to create them, but this must not be allowed for superadmins
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: not context.fine_grained_auth_provider.is_user_a_superadmin(user_id),
         public_msg=f"User id: {user_id} cannot be given a role in no organisation with ID {str(org_id)}.",
@@ -432,7 +422,6 @@ def remove_user_from_reporting_org(
 
     # 1. Check if the requesting user has permission to update roles for this org
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: user.validator.user_can_modify_user_roles_for_reporting_org(org_id),
         status_code=fastapi.status.HTTP_403_FORBIDDEN,
@@ -451,7 +440,6 @@ def remove_user_from_reporting_org(
 
     # 2. Check that the target user exists in CRM
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: check_crm_record_exists(crm, "Contacts", str(user_id)),
         public_msg=f"There is no user with ID {str(user_id)} in the Registry.",
@@ -464,7 +452,6 @@ def remove_user_from_reporting_org(
 
     # 3. Check that the reporting org exists in CRM
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: check_crm_record_exists(crm, "Accounts", str(org_id)),
         public_msg=f"There is no organisation with ID {str(org_id)} in the Registry.",
@@ -478,7 +465,6 @@ def remove_user_from_reporting_org(
     user_role_for_org = context.fine_grained_auth_provider.get_user_role_for_org(user_id, org_id)
 
     assert_precondition_met(
-        context,
         user,
         condition_func=lambda: user_role_for_org is not None,
         public_msg=f"User id: {user_id} has no role in organisation with id: {str(org_id)} in the Registry.",

--- a/src/register_your_data_api/routers/users.py
+++ b/src/register_your_data_api/routers/users.py
@@ -129,7 +129,8 @@ def add_user_to_reporting_org(
         context.audit_logger.info(
             format_log_msg(
                 request,
-                user,
+                user.user_id_crm,
+                user.client_id,
                 (
                     f"trace id: {trace_id} - request to join organisation id: "
                     f"{payload.oid_str} - crm relationship created."
@@ -149,7 +150,8 @@ def add_user_to_reporting_org(
         context.audit_logger.info(
             format_log_msg(
                 request,
-                user,
+                user.user_id_crm,
+                user.client_id,
                 (
                     f"trace id: {trace_id} - request to join organisation id: "
                     f"{payload.oid_str} - entry in FGA DB created."
@@ -193,7 +195,8 @@ def add_user_to_reporting_org(
             context.app_logger.error(
                 format_log_msg(
                     request,
-                    user,
+                    user.user_id_crm,
+                    user.client_id,
                     (
                         f"trace id: {trace_id} - User requested to join organisation id: {payload.oid_str} and "
                         "their request has been processed but no admins were found for this organisation so no email "
@@ -213,7 +216,8 @@ def add_user_to_reporting_org(
     context.audit_logger.info(
         format_log_msg(
             request,
-            user,
+            user.user_id_crm,
+            user.client_id,
             (f"trace id: {trace_id} - request to join organisation id: {payload.oid_str} succeeded."),
             include_client_id=True,
         )
@@ -396,7 +400,8 @@ def update_user_role_in_reporting_org(
     context.audit_logger.info(
         format_log_msg(
             request,
-            user,
+            user.user_id_crm,
+            user.client_id,
             (
                 f"request to change user id: {user_id}'s role for organisation with id: {org_id} "
                 f"to '{new_role.role}' by authorised user with id: {user.user_id_crm} succeeded."
@@ -482,7 +487,8 @@ def remove_user_from_reporting_org(
         context.audit_logger.info(
             format_log_msg(
                 request,
-                user,
+                user.user_id_crm,
+                user.client_id,
                 f"Request to remove user id: {user_id}'s from organisation with id: {org_id} succeeded",
                 include_client_id=True,
             )

--- a/src/register_your_data_api/services/suitecrm_common.py
+++ b/src/register_your_data_api/services/suitecrm_common.py
@@ -56,7 +56,12 @@ def get_reporting_orgs_for_user(
             f"{user_to_fetch_str} from SuiteCRM. Details: {str(e)}"
         )
         raise RYDUserException(
-            requesting_user, 500, app_msg=None, audit_msg=audit_message, public_msg=public_error_message
+            requesting_user.user_id_crm,
+            requesting_user.client_id,
+            500,
+            app_msg=None,
+            audit_msg=audit_message,
+            public_msg=public_error_message,
         )
 
     total_records = orgs_for_user.get("meta", {}).get("total-records", 0)

--- a/src/register_your_data_api/utilities.py
+++ b/src/register_your_data_api/utilities.py
@@ -3,13 +3,13 @@ from typing import Any, Callable
 
 from libsuitecrm import Filter, SuiteCRM  # type: ignore
 
-from .auth.models import UserAndCredentials
 from .exceptions import RYDUserException
 from .util import Context
 
 
 def assert_precondition_met(
-    user: UserAndCredentials,
+    user_id: str,
+    client_id: str,
     condition_func: Callable[[], bool],
     public_msg: str,
     status_code: int,
@@ -20,8 +20,10 @@ def assert_precondition_met(
 
     Parameters
     ----------
-    user : UserAndCredentials
-        The user and details about their credentials performing the action
+    user_id : str
+        The ID of the user performing the action
+    client_id : str
+        The client ID of the application the user is using
     condition_func : Callable[[], bool]
         A function that returns True if the precondition is met
     public_msg : str
@@ -41,8 +43,8 @@ def assert_precondition_met(
     if not condition_func():
 
         raise RYDUserException(
-            user_id=user.user_id_crm,
-            client_id=user.client_id,
+            user_id=user_id,
+            client_id=client_id,
             status_code=status_code,
             app_msg=app_log_msg,
             audit_msg=audit_log_msg,

--- a/src/register_your_data_api/utilities.py
+++ b/src/register_your_data_api/utilities.py
@@ -41,7 +41,8 @@ def assert_precondition_met(
     if not condition_func():
 
         raise RYDUserException(
-            user=user,
+            user_id=user.user_id_crm,
+            client_id=user.client_id,
             status_code=status_code,
             app_msg=app_log_msg,
             audit_msg=audit_log_msg,

--- a/src/register_your_data_api/utilities.py
+++ b/src/register_your_data_api/utilities.py
@@ -9,7 +9,6 @@ from .util import Context
 
 
 def assert_precondition_met(
-    context: Context,
     user: UserAndCredentials,
     condition_func: Callable[[], bool],
     public_msg: str,
@@ -21,8 +20,6 @@ def assert_precondition_met(
 
     Parameters
     ----------
-    context : Context
-        The application context
     user : UserAndCredentials
         The user and details about their credentials performing the action
     condition_func : Callable[[], bool]

--- a/tests/integration/test_users_routes.py
+++ b/tests/integration/test_users_routes.py
@@ -244,6 +244,46 @@ def test_delete_user_role_permissions_check(logged_in_user_idx: int, expected_st
 
 
 @pytest.mark.parametrize(
+    "logged_in_user_idx,expected_status_code",
+    [
+        (1, 400),  # Person 2 (User index 1) is an ADMIN - can delete roles, but should get 400 for last user
+    ],
+)
+def test_delete_user_role_cannot_delete_last_user(logged_in_user_idx: int, expected_status_code: int) -> None:
+    appAndContext = MockedAppAndContext()
+
+    fastAPIapp = appAndContext.get_test_app()
+
+    with TestClient(fastAPIapp) as client:
+        response = client.delete(
+            "/api/v1/users/bea511d3-c7a7-4097-55ed-68de81e94921/reporting-org/da17734d-3926-47ef-8563-8a1b0247ed11",
+            headers=appAndContext.get_valid_authorization_header(logged_in_user_idx),
+        )
+
+        assert response.status_code == expected_status_code
+
+
+@pytest.mark.parametrize(
+    "logged_in_user_idx,expected_status_code",
+    [
+        (1, 400),  # Person 2 (User index 1) is an ADMIN - can delete roles, but should get 400 for last admin user
+    ],
+)
+def test_delete_user_role_cannot_delete_last_admin_user(logged_in_user_idx: int, expected_status_code: int) -> None:
+    appAndContext = MockedAppAndContext()
+
+    fastAPIapp = appAndContext.get_test_app()
+
+    with TestClient(fastAPIapp) as client:
+        response = client.delete(
+            "/api/v1/users/bea511d3-c7a7-4097-55ed-68de81e94921/reporting-org/698e0c1f-4e80-faa9-6533-68de801d1735",
+            headers=appAndContext.get_valid_authorization_header(logged_in_user_idx),
+        )
+
+        assert response.status_code == expected_status_code
+
+
+@pytest.mark.parametrize(
     "logged_in_user_idx,user_to_modify,expected_status_code",
     [
         (2, "7625122c-f752-40dc-a577-5cb49e13de2a", 200),


### PR DESCRIPTION
This PR:
* Refactors the `assert_precondition_met` function and the `RYDUserException` class, removing their dependencies on rich context objects, and making them depend only on primitive values they require - this should make it easier to test.
* Adds tests to check the the last user and the last admin user of an org can't be deleted.
* Implements checks to ensure that the last user and last admin users cannot be deleted.

NOTE: this PR is setup as a compare against the `sk-search-discoverable-orgs` branch - the pre-existing PR for that branch (#70) should be merged and this branch rebased onto develop before merging this.

This should close issues #47 and #71.