### PR TITLE
Change permissions for provider admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.3.4] - 2026-04-20
+
+### Fixed
+
+ - Dataset creation endpoint now returns 201 rather than 200.
+
+### Changed
+
+ - Permissions for provider admin user role.
+
+### Added
+
+ - Integration tests for creating and deleting datasets, and updating organisations.
+
+
 ## [0.3.3] - 2026-04-15
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "register-your-data-api"
-version = "0.3.3"
+version = "0.3.4"
 requires-python = ">= 3.12.11"
 readme = "README.md"
 authors = [{name="IATI Secretariat", email="support@iatistandard.org"}]

--- a/src/register_your_data_api/auth/fga/fga_validator.py
+++ b/src/register_your_data_api/auth/fga/fga_validator.py
@@ -25,9 +25,12 @@ class FineGrainedAuthorisationUserValidator(pydantic.BaseModel):
         ]
         permissions[FineGrainedAuthorisationRole.PROVIDER_ADMIN] = [
             "read-org",
+            "update-org",
             "read-dataset",
+            "create-dataset",
             "update-dataset",
             "update-dataset-visibility",
+            "delete-dataset",
         ]
         permissions[FineGrainedAuthorisationRole.ADMIN] = [
             *permissions[FineGrainedAuthorisationRole.EDITOR],

--- a/src/register_your_data_api/routers/datasets.py
+++ b/src/register_your_data_api/routers/datasets.py
@@ -32,7 +32,7 @@ from ..data_handling.data_schemas import (
 router = fastapi.APIRouter(prefix="/api/v1/datasets")
 
 
-@router.post("")
+@router.post("", status_code=201)
 def create_dataset(
     request: starlette.requests.Request,
     dataset: DatasetCreateModel,

--- a/tests/helpers/mocked_objects/mock_suitecrm.py
+++ b/tests/helpers/mocked_objects/mock_suitecrm.py
@@ -109,17 +109,26 @@ class MockSuiteCRM:
     def create_record(
         self, module_name: str, data: dict[str, Any], headers: dict[str, str] | None = None
     ) -> dict[str, Any]:
-        return {
-            "id": str(uuid.uuid4()),
-            "attributes": {
-                "created_date": get_current_timestamp_as_str(),
-                "first_publication_date": "",
-                "registry_approved": "0",
-                "iati_url_update_date": "",
-                "iati_metadata_update_date": "",
-                **data,
-            },
-        }
+        if "IATI_Dataset" in module_name:
+            return {
+                "id": str(uuid.uuid4()),
+                "type": "IATI_Datasets",
+                "attributes": {"iati_url_update_date": "", "iati_metadata_update_date": "", **data},
+            }
+        elif "Account" in module_name:
+            return {
+                "id": str(uuid.uuid4()),
+                "attributes": {
+                    "created_date": get_current_timestamp_as_str(),
+                    "first_publication_date": "",
+                    "registry_approved": "0",
+                    "iati_url_update_date": "",
+                    "iati_metadata_update_date": "",
+                    **data,
+                },
+            }
+
+        return {}
 
     def update_record(
         self, module_name: str, id: str, data: dict[str, Any], headers: dict[str, str] | None = None

--- a/tests/helpers/mocked_objects/mock_suitecrm.py
+++ b/tests/helpers/mocked_objects/mock_suitecrm.py
@@ -139,6 +139,12 @@ class MockSuiteCRM:
                 "type": "IATI_Datasets",
                 "attributes": {"iati_url_update_date": "", "iati_metadata_update_date": "", **data},
             }
+        if "Account" in module_name:
+            return {
+                "id": id,
+                "type": "Accounts",
+                "attributes": {**data},
+            }
 
         return {}
 

--- a/tests/integration/test_dataset_routes.py
+++ b/tests/integration/test_dataset_routes.py
@@ -182,3 +182,31 @@ def test_create_dataset(user: int, status_code: int, organisation_id: str) -> No
         )
 
         assert response.status_code == status_code
+
+
+@pytest.mark.parametrize(
+    "user,status_code,dataset_id",
+    [
+        (0, 200, "52ac525f-6375-079b-977d-68ecf3be2868"),  # Editor of org
+        (1, 200, "52ac525f-6375-079b-977d-68ecf3be2868"),  # Admin of org
+        (2, 200, "52ac525f-6375-079b-977d-68ecf3be2868"),  # Superadmin
+        (3, 403, "52ac525f-6375-079b-977d-68ecf3be2868"),  # Contributor of org
+        (3, 403, "4ad2b196-aa31-983e-93d9-68ecf476a2c6"),  # Contributor pending in org
+        (4, 200, "52ac525f-6375-079b-977d-68ecf3be2868"),  # Provider admin via Tool One
+        (6, 500, "52ac525f-6375-079b-977d-68ecf3be2868"),  # Failure: has provider admin and org role
+    ],
+)
+def test_delete_dataset(user: int, status_code: int, dataset_id: str) -> None:
+
+    appAndContext = MockedAppAndContext()
+
+    fastAPIapp = appAndContext.get_test_app()
+
+    with TestClient(fastAPIapp) as client:
+
+        response = client.delete(
+            f"/api/v1/datasets/{dataset_id}",
+            headers=appAndContext.get_valid_authorization_header(user),
+        )
+
+        assert response.status_code == status_code

--- a/tests/integration/test_dataset_routes.py
+++ b/tests/integration/test_dataset_routes.py
@@ -87,7 +87,7 @@ def test_dataset_update_with_invalid_short_name(invalid_short_name: str) -> None
             content=json.dumps(dataset),
         )
 
-        assert response_create.status_code == 200
+        assert response_create.status_code == 201
 
         resp_create_obj = response_create.json()
 

--- a/tests/integration/test_dataset_routes.py
+++ b/tests/integration/test_dataset_routes.py
@@ -143,3 +143,42 @@ def test_change_dataset_visibility(user: int, status_code: int) -> None:
         )
 
         assert response.status_code == status_code
+
+
+@pytest.mark.parametrize(
+    "user,status_code,organisation_id",
+    [
+        (0, 201, "552376ae-2aa7-98ab-d800-68daa9bfeb4a"),  # Editor of org
+        (1, 201, "552376ae-2aa7-98ab-d800-68daa9bfeb4a"),  # Admin of org
+        (2, 201, "552376ae-2aa7-98ab-d800-68daa9bfeb4a"),  # Superadmin
+        (3, 201, "552376ae-2aa7-98ab-d800-68daa9bfeb4a"),  # Contributor of org
+        (3, 403, "ab851a83-a384-3eb9-caf0-68db8125b067"),  # Contributor pending in org
+        (4, 201, "552376ae-2aa7-98ab-d800-68daa9bfeb4a"),  # Provider admin via Tool One
+        (6, 500, "552376ae-2aa7-98ab-d800-68daa9bfeb4a"),  # Failure: has provider admin and org role
+    ],
+)
+def test_create_dataset(user: int, status_code: int, organisation_id: str) -> None:
+
+    appAndContext = MockedAppAndContext()
+
+    fastAPIapp = appAndContext.get_test_app()
+
+    with TestClient(fastAPIapp) as client:
+
+        response = client.post(
+            "/api/v1/datasets",
+            headers=appAndContext.get_valid_authorization_header(user),
+            content=json.dumps(
+                {
+                    "human_readable_name": "Aid Agency - Dataset 01",
+                    "licence_id": "cc-zero",
+                    "short_name": "aidagy-data-01",
+                    "source_type": "primary_source",
+                    "url": "http://aidagency.com/dataset-01.xml",
+                    "visibility": "private",
+                    "owner_organisation_id": organisation_id,
+                }
+            ),
+        )
+
+        assert response.status_code == status_code

--- a/tests/integration/test_reporting_org_routes.py
+++ b/tests/integration/test_reporting_org_routes.py
@@ -461,6 +461,44 @@ def test_reporting_org_create_with_invalid_short_name(invalid_short_name: str) -
         assert response_obj["status"] == "failed"
 
 
+@pytest.mark.parametrize(
+    "user,status_code,organisation_id",
+    [
+        (0, 200, "552376ae-2aa7-98ab-d800-68daa9bfeb4a"),  # Editor of org
+        (1, 200, "552376ae-2aa7-98ab-d800-68daa9bfeb4a"),  # Admin of org
+        (2, 200, "552376ae-2aa7-98ab-d800-68daa9bfeb4a"),  # Superadmin
+        (3, 403, "552376ae-2aa7-98ab-d800-68daa9bfeb4a"),  # Contributor of org
+        (3, 403, "ab851a83-a384-3eb9-caf0-68db8125b067"),  # Contributor pending in org
+        (4, 200, "552376ae-2aa7-98ab-d800-68daa9bfeb4a"),  # Provider admin via Tool One
+        (4, 403, "da17734d-3926-47ef-8563-8a1b0247ed11"),  # Provider admin but Tool has no permission for org
+        (6, 500, "552376ae-2aa7-98ab-d800-68daa9bfeb4a"),  # Failure: has provider admin and org role
+    ],
+)
+def test_reporting_org_update(user: int, status_code: int, organisation_id: str) -> None:
+    appAndContext = MockedAppAndContext()
+
+    fastAPIapp = appAndContext.get_test_app()
+
+    with TestClient(fastAPIapp) as client:
+        # Get the organisation record using the superadmin user, so we have the record
+        # to tweak and test the actual user.
+        response = client.get(
+            f"/api/v1/reporting-orgs/{organisation_id}",
+            headers=appAndContext.get_valid_authorization_header(2),
+        )
+
+        assert response.status_code == 200
+
+        payload = response.json()
+        payload["contact_email"] = "changed.email@example.org"
+
+        response = client.patch(
+            f"/api/v1/reporting-orgs/{organisation_id}",
+            headers=appAndContext.get_valid_authorization_header(user),
+            content=json.dumps(payload),
+        )
+
+
 @pytest.mark.parametrize("user,status_code", [(0, 403), (1, 200), (2, 200), (3, 403), (4, 403)])
 def test_reporting_org_delete(user: int, status_code: int) -> None:
     appAndContext = MockedAppAndContext()

--- a/tests/unit/test_fga_validator.py
+++ b/tests/unit/test_fga_validator.py
@@ -28,13 +28,13 @@ def test_provider_admin() -> None:
 
     assert v.user_can_create_reporting_org()
 
-    assert not v.user_can_update_reporting_org(org1)
+    assert v.user_can_update_reporting_org(org1)
     assert not v.user_can_update_reporting_org(org2)
 
     assert not v.user_can_delete_reporting_org(org1)
     assert not v.user_can_delete_reporting_org(org2)
 
-    assert not v.user_can_create_reporting_org_datasets(org1)
+    assert v.user_can_create_reporting_org_datasets(org1)
     assert not v.user_can_create_reporting_org_datasets(org2)
 
     assert v.user_can_update_reporting_org_datasets(org1)
@@ -43,7 +43,7 @@ def test_provider_admin() -> None:
     assert v.user_can_update_reporting_org_dataset_visibility(org1)
     assert not v.user_can_update_reporting_org_dataset_visibility(org2)
 
-    assert not v.user_can_delete_reporting_org_datasets(org1)
+    assert v.user_can_delete_reporting_org_datasets(org1)
     assert not v.user_can_delete_reporting_org_datasets(org2)
 
     assert not v.user_can_modify_user_roles_for_reporting_org(org1)


### PR DESCRIPTION
This PR mainly changes the permissions for the provider admin role to add `update-org`, `create-dataset`, and `delete-dataset`.  It also:

* Fixes the create dataset endpoint to return HTTP 201.
* Adds additional tests for creating datasets, updating organisations, deleting datasets.
